### PR TITLE
将havenask镜像版本升级到0.3.0

### DIFF
--- a/buildSrc/version.properties
+++ b/buildSrc/version.properties
@@ -1,6 +1,6 @@
 havenask        = 1.0.0
 lucene          = 8.7.0
-runtime_image   = 0.2.2
+runtime_image   = 0.3.0
 
 bundled_jdk_vendor = openjdk
 bundled_jdk = 15+36@779bf45e88a44cbd9ea6621d33e33db1


### PR DESCRIPTION
将havenask镜像版本升级到0.3.0。
havanask发布了0.3.0版本，具体介绍见：https://github.com/alibaba/havenask/wiki/havenask:0.3.0
