### PR TITLE
启动searcher、qrs时指定tcp端口

### DIFF
--- a/modules/havenask-engine/config/havenask/script/general_search_starter.py
+++ b/modules/havenask-engine/config/havenask/script/general_search_starter.py
@@ -72,7 +72,7 @@ examples:
         self.parser.add_option('-c', '--config', action='store', dest='configPath')
         self.parser.add_option('-p', '--port', action='store', dest='portList')
         self.parser.add_option('', '--httpBindPort', dest='httpBindPort', type='int', default=0)
-        self.parser.add_option('', '--qrsArpcBindPort', dest='qrsArpcBindPort', type='int', default=0)
+        self.parser.add_option('', '--arpcBindPort', dest='arpcBindPort', type='int', default=0)
 
         self.parser.add_option('-z', '--zone', action='store', dest='zoneName')
         self.parser.add_option('-j', '--tables', action='store', dest='atables')
@@ -173,7 +173,7 @@ examples:
             self.offlineConfigPath = os.path.join(self.offlineConfigPath, str(tableVersions[-1]))
 
         self.httpBindPort = options.httpBindPort
-        self.qrsArpcBindPort = options.qrsArpcBindPort
+        self.arpcBindPort = options.arpcBindPort
         self.portList = []
         # self.origin_port_list = map(lambda x:int(x), options.portList.split(","))
         self.searcher_port_list = []
@@ -545,9 +545,9 @@ examples:
         targetCfg = os.path.join(rundir, "qrs_service_%d.cfg" % (self.portStart))
         os.system("cp %s %s" % (self.qrsCfg, targetCfg))
         startCmd = self.startCmdTemplate % (self.binPath, self.libPath, self.alogConfigPath,
-                                            self.binaryPath, targetCfg, 0, 0,
+                                            self.binaryPath, targetCfg, self.arpcBindPort, 0,
                                             self.httpBindPort, self.serviceName,self.serviceName,
-                                            zoneName, self.amonPort, "qrs", self.qrsArpcBindPort, self.ip, zoneName, zoneName, partId)
+                                            zoneName, self.amonPort, "qrs", self.arpcBindPort, self.ip, zoneName, zoneName, partId)
         if self.qrsQueue :
             startCmd += " --env extraTaskQueues=" + self.qrsQueue
         if self.qrsQueueSize :
@@ -613,8 +613,8 @@ examples:
             targetCfg = os.path.join(rundir, zoneName + "_%d_search_service_%d.cfg" % (partId, self.portStart))
             os.system("cp %s %s" % (self.searchCfg, targetCfg))
             startCmd = self.startCmdTemplate % (self.binPath, self.libPath, self.alogConfigPath,
-                                                self.binaryPath, targetCfg, 0, 0, self.httpBindPort, self.serviceName, self.serviceName,
-                                                zoneName, self.amonPort, "searcher", 0, self.ip, zoneName, zoneName, partId )
+                                                self.binaryPath, targetCfg, self.arpcBindPort, 0, self.httpBindPort, self.serviceName, self.serviceName,
+                                                zoneName, self.amonPort, "searcher", self.arpcBindPort, self.ip, zoneName, zoneName, partId )
             if self.searcherQueue :
                 startCmd += " --env extraTaskQueues=" + self.searcherQueue
             if self.searcherQueueSize :

--- a/modules/havenask-engine/src/main/java/org/havenask/engine/NativeProcessControlService.java
+++ b/modules/havenask-engine/src/main/java/org/havenask/engine/NativeProcessControlService.java
@@ -42,9 +42,9 @@ public class NativeProcessControlService extends AbstractLifecycleComponent {
     public static final String SEARCHER_ROLE = "searcher";
     public static final String QRS_ROLE = "qrs";
     private static final String START_SEARCHER_COMMAND = "cd %s;python %s/havenask/script/general_search_starter.py -i "
-        + "%s -c %s -b /ha3_install -M in0 --role searcher --httpBindPort %d";
+        + "%s -c %s -b /ha3_install -M in0 --role searcher --httpBindPort %d --arpcBindPort %d";
     private static final String START_QRS_COMMAND = "cd %s;python %s/havenask/script/general_search_starter.py -i "
-        + "%s -c %s -b /ha3_install -M in0 --role qrs --httpBindPort %d";
+        + "%s -c %s -b /ha3_install -M in0 --role qrs --httpBindPort %d --arpcBindPort %d";
     private static final String UPDATE_SEARCHER_COMMAND = "cd %s;python %s/havenask/script/general_search_updater.py -i "
         + "%s -c %s -M in0 --role searcher";
     private static final String UPDATE_QRS_COMMAND = "cd %s;python %s/havenask/script/general_search_updater.py -i "
@@ -63,9 +63,23 @@ public class NativeProcessControlService extends AbstractLifecycleComponent {
         Setting.Property.Final
     );
 
+    public static final Setting<Integer> HAVENASK_SEARCHER_TCP_PORT_SETTING = Setting.intSetting(
+        "havenask.searcher.tcp.port",
+        39300,
+        Property.NodeScope,
+        Setting.Property.Final
+    );
+
     public static final Setting<Integer> HAVENASK_QRS_HTTP_PORT_SETTING = Setting.intSetting(
         "havenask.qrs.http.port",
         49200,
+        Property.NodeScope,
+        Setting.Property.Final
+    );
+
+    public static final Setting<Integer> HAVENASK_QRS_TCP_PORT_SETTING = Setting.intSetting(
+        "havenask.qrs.tcp.port",
+        49300,
         Property.NodeScope,
         Setting.Property.Final
     );
@@ -79,7 +93,9 @@ public class NativeProcessControlService extends AbstractLifecycleComponent {
     private final NodeEnvironment nodeEnvironment;
     private final HavenaskEngineEnvironment havenaskEngineEnvironment;
     private final int searcherHttpPort;
+    private final int searcherTcpPort;
     private final int qrsHttpPort;
+    private final int qrsTcpPort;
 
     protected String startSearcherCommand;
     protected String updateSearcherCommand;
@@ -107,7 +123,9 @@ public class NativeProcessControlService extends AbstractLifecycleComponent {
         this.nodeEnvironment = nodeEnvironment;
         this.havenaskEngineEnvironment = havenaskEngineEnvironment;
         this.searcherHttpPort = HAVENASK_SEARCHER_HTTP_PORT_SETTING.get(settings);
+        this.searcherTcpPort = HAVENASK_SEARCHER_TCP_PORT_SETTING.get(settings);
         this.qrsHttpPort = HAVENASK_QRS_HTTP_PORT_SETTING.get(settings);
+        this.qrsTcpPort = HAVENASK_QRS_TCP_PORT_SETTING.get(settings);
         this.startSearcherCommand = String.format(
             Locale.ROOT,
             START_SEARCHER_COMMAND,
@@ -115,7 +133,8 @@ public class NativeProcessControlService extends AbstractLifecycleComponent {
             environment.configFile().toAbsolutePath(),
             havenaskEngineEnvironment.getRuntimedataPath(),
             havenaskEngineEnvironment.getConfigPath(),
-            searcherHttpPort
+            searcherHttpPort,
+            searcherTcpPort
         );
         this.updateSearcherCommand = String.format(
             Locale.ROOT,
@@ -132,7 +151,8 @@ public class NativeProcessControlService extends AbstractLifecycleComponent {
             environment.configFile().toAbsolutePath(),
             havenaskEngineEnvironment.getRuntimedataPath(),
             havenaskEngineEnvironment.getConfigPath(),
-            qrsHttpPort
+            qrsHttpPort,
+            qrsTcpPort
         );
         this.updateQrsCommand = String.format(
             Locale.ROOT,


### PR DESCRIPTION
启动searcher、qrs时指定tcp端口。
之前不指定searcher tcp端口，searcher重启后，会使用新的port，导致qrs无法访问，指定searcher tcp端口后，可以解决该问题。