### PR TITLE
只有在创建havenask索引时，才自动加上replica=0

### DIFF
--- a/modules/havenask-engine/src/main/java/org/havenask/engine/HavenaskIndexSettingProvider.java
+++ b/modules/havenask-engine/src/main/java/org/havenask/engine/HavenaskIndexSettingProvider.java
@@ -15,17 +15,23 @@
 package org.havenask.engine;
 
 import org.havenask.common.settings.Settings;
+import org.havenask.engine.index.engine.EngineSettings;
 import org.havenask.index.shard.IndexSettingProvider;
 
 import static org.havenask.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_REPLICAS;
 
 public class HavenaskIndexSettingProvider implements IndexSettingProvider {
     public Settings getAdditionalIndexSettings(String indexName, boolean isDataStreamIndex, Settings templateAndRequestSettings) {
-        int replica = templateAndRequestSettings.getAsInt(SETTING_NUMBER_OF_REPLICAS, 0);
-        if (replica != 0) {
-            throw new IllegalArgumentException("havenask engine only support 0 replica");
+        if (EngineSettings.isHavenaskEngine(templateAndRequestSettings)) {
+            int replica = templateAndRequestSettings.getAsInt(SETTING_NUMBER_OF_REPLICAS, 0);
+            if (replica != 0) {
+                throw new IllegalArgumentException("havenask engine only support 0 replica");
+            }
+            return Settings.builder()
+                .put(SETTING_NUMBER_OF_REPLICAS, 0)
+                .build();
+        } else {
+            return Settings.EMPTY;
         }
-
-        return Settings.builder().put(SETTING_NUMBER_OF_REPLICAS, 0).build();
     }
 }

--- a/modules/havenask-engine/src/test/java/org/havenask/engine/HavenaskIndexSettingProviderTests.java
+++ b/modules/havenask-engine/src/test/java/org/havenask/engine/HavenaskIndexSettingProviderTests.java
@@ -24,7 +24,7 @@ public class HavenaskIndexSettingProviderTests extends HavenaskTestCase {
     public void testGetAdditionalIndexSettings() {
         HavenaskIndexSettingProvider provider = new HavenaskIndexSettingProvider();
         Settings settings = provider.getAdditionalIndexSettings("test", false, Settings.builder().put("index.engine", "havenask").build());
-        int replicas = settings.getAsInt(SETTING_NUMBER_OF_REPLICAS, -1);
+        int replicas = settings.getAsInt(SETTING_NUMBER_OF_REPLICAS, 2);
         assertEquals(0, replicas);
     }
 
@@ -41,5 +41,28 @@ public class HavenaskIndexSettingProviderTests extends HavenaskTestCase {
         } catch (IllegalArgumentException e) {
             assertEquals("havenask engine only support 0 replica", e.getMessage());
         }
+    }
+
+    // test for havenask engine only support 0 replica
+    public void testGetAdditionalIndexSettingsWithReplica2() {
+        HavenaskIndexSettingProvider provider = new HavenaskIndexSettingProvider();
+        try {
+            provider.getAdditionalIndexSettings(
+                "test",
+                false,
+                Settings.builder().put("index.engine", "havenask").put(SETTING_NUMBER_OF_REPLICAS, 2).build()
+            );
+            fail("should throw IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            assertEquals("havenask engine only support 0 replica", e.getMessage());
+        }
+    }
+
+    // test not havenask engine
+    public void testGetAdditionalIndexSettingsWithNotHavenaskEngine() {
+        HavenaskIndexSettingProvider provider = new HavenaskIndexSettingProvider();
+        Settings settings = provider.getAdditionalIndexSettings("test", false, Settings.builder().build());
+        int replicas = settings.getAsInt(SETTING_NUMBER_OF_REPLICAS, 2);
+        assertEquals(2, replicas);
     }
 }


### PR DESCRIPTION
普通索引不默认加上replica=0配置，只有havenask索引才添加