### PR TITLE
添加opensearch-dashboard到镜像中，可以支持可视化查看havenask索引

### DIFF
--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -110,6 +110,10 @@ project.ext {
         from project.projectDir.toPath().resolve("src/docker/config")
       }
 
+      into('packages') {
+        from project.projectDir.toPath().resolve("src/docker/packages")
+      }
+
       from(project.projectDir.toPath().resolve("src/docker/Dockerfile")) {
         expand(expansions(architecture, base, local))
       }

--- a/distribution/docker/src/docker/Dockerfile
+++ b/distribution/docker/src/docker/Dockerfile
@@ -33,6 +33,9 @@ RUN chmod 0775 config config/jvm.options.d data logs
 COPY config/havenask.yml config/log4j2.properties config/
 RUN chmod 0660 config/havenask.yml config/log4j2.properties
 
+# add opensearch-dashboard
+ADD "./packages/dashboards.tar.gz" "/usr/share/havenask/"
+
 ################################################################################
 # Build stage 1 (the actual Havenask image):
 #

--- a/script/create_container.sh
+++ b/script/create_container.sh
@@ -43,7 +43,7 @@ echo "Info: Container entry: $CONTAINER_DIR"
 mkdir -p $CONTAINER_DIR
 
 
-docker run -p 9200:9200 -p 5005:5005 -p 39200:39200 -p 49200:49200 --ulimit nofile=655350:655350 --privileged --cap-add SYS_ADMIN --device /dev/fuse --ulimit memlock=-1 --cpu-shares=15360 --cpu-quota=9600000 --cpu-period=100000 --memory=500000m -d  --name $CONTAINER_NAME -v $CONTAINER_DIR/initContainer.sh:/tmp/initContainer.sh $IMAGE /sbin/init 1> /dev/null
+docker run -p 9200:9200 -p 5005:5005 -p 39200:39200 -p 49200:49200 -p 5601:5601 --ulimit nofile=655350:655350 --privileged --cap-add SYS_ADMIN --device /dev/fuse --ulimit memlock=-1 --cpu-shares=15360 --cpu-quota=9600000 --cpu-period=100000 --memory=500000m -d  --name $CONTAINER_NAME -v $CONTAINER_DIR/initContainer.sh:/tmp/initContainer.sh $IMAGE /sbin/init 1> /dev/null
 
 
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
添加opensearch-dashboard到镜像中，启动镜像后，可以通过如下方式启动opensearch-dashboard(先确保havenask federation进程已正常启动)：
```
cd dashboards
./bin/opensearch-dashboards
```
启动dashboard后，在浏览器访问节点的5601端口，比如在本地启动的话，在浏览器访问：http://127.0.0.1:5601/
