### PR TITLE
增加对havenask realtime kafka_start_timestamp参数支持

### DIFF
--- a/modules/havenask-engine/src/main/java/org/havenask/engine/HavenaskEnginePlugin.java
+++ b/modules/havenask-engine/src/main/java/org/havenask/engine/HavenaskEnginePlugin.java
@@ -155,7 +155,8 @@ public class HavenaskEnginePlugin extends Plugin implements EnginePlugin, Analys
             EngineSettings.HA3_FLOAT_MUL_BY10,
             EngineSettings.HAVENASK_REALTIME_ENABLE,
             EngineSettings.HAVENASK_REALTIME_TOPIC_NAME,
-            EngineSettings.HAVENASK_REALTIME_BOOTSTRAP_SERVERS
+            EngineSettings.HAVENASK_REALTIME_BOOTSTRAP_SERVERS,
+            EngineSettings.HAVENASK_REALTIME_KAFKA_START_TIMESTAMP
         );
     }
 

--- a/modules/havenask-engine/src/main/java/org/havenask/engine/index/config/RealtimeInfo.java
+++ b/modules/havenask-engine/src/main/java/org/havenask/engine/index/config/RealtimeInfo.java
@@ -42,13 +42,13 @@ public class RealtimeInfo {
     public String bootstrap_servers;
     public String src_signature = "16113477091138423397";
     public String realtime_process_rawdoc = "true";
-    public long kafka_start_timestamp = 0;
+    public String kafka_start_timestamp = "0";
 
     public RealtimeInfo(String data_table, String topic_name, String bootstrap_servers, long kafka_start_timestamp) {
         this.data_table = data_table;
         this.topic_name = topic_name;
         this.bootstrap_servers = bootstrap_servers;
-        this.kafka_start_timestamp = kafka_start_timestamp;
+        this.kafka_start_timestamp = String.valueOf(kafka_start_timestamp);
     }
 
     @Override

--- a/modules/havenask-engine/src/main/java/org/havenask/engine/index/config/RealtimeInfo.java
+++ b/modules/havenask-engine/src/main/java/org/havenask/engine/index/config/RealtimeInfo.java
@@ -42,11 +42,13 @@ public class RealtimeInfo {
     public String bootstrap_servers;
     public String src_signature = "16113477091138423397";
     public String realtime_process_rawdoc = "true";
+    public long kafka_start_timestamp = 0;
 
-    public RealtimeInfo(String data_table, String topic_name, String bootstrap_servers) {
+    public RealtimeInfo(String data_table, String topic_name, String bootstrap_servers, long kafka_start_timestamp) {
         this.data_table = data_table;
         this.topic_name = topic_name;
         this.bootstrap_servers = bootstrap_servers;
+        this.kafka_start_timestamp = kafka_start_timestamp;
     }
 
     @Override

--- a/modules/havenask-engine/src/main/java/org/havenask/engine/index/config/generator/RuntimeSegmentGenerator.java
+++ b/modules/havenask-engine/src/main/java/org/havenask/engine/index/config/generator/RuntimeSegmentGenerator.java
@@ -47,7 +47,8 @@ public class RuntimeSegmentGenerator {
             if (realTime) {
                 String topic = EngineSettings.HAVENASK_REALTIME_TOPIC_NAME.get(settings);
                 String bootstrapServers = EngineSettings.HAVENASK_REALTIME_BOOTSTRAP_SERVERS.get(settings);
-                RealtimeInfo realtimeInfo = new RealtimeInfo(indexName, topic, bootstrapServers);
+                long kafkaStartTimestamp = EngineSettings.HAVENASK_REALTIME_KAFKA_START_TIMESTAMP.get(settings);
+                RealtimeInfo realtimeInfo = new RealtimeInfo(indexName, topic, bootstrapServers, kafkaStartTimestamp);
 
                 nativeProcessControlService.startBsJob(indexName, realtimeInfo.toString());
             } else {

--- a/modules/havenask-engine/src/main/java/org/havenask/engine/index/engine/EngineSettings.java
+++ b/modules/havenask-engine/src/main/java/org/havenask/engine/index/engine/EngineSettings.java
@@ -116,6 +116,15 @@ public class EngineSettings {
         Property.Final
     );
 
+    // index.havenask.realtime.kafka_start_timestamp
+    public static final Setting<Long> HAVENASK_REALTIME_KAFKA_START_TIMESTAMP = Setting.longSetting(
+        "index.havenask.realtime.kafka_start_timestamp",
+        0L,
+        0L,
+        Setting.Property.IndexScope,
+        Property.Final
+    );
+
     public static boolean isHavenaskEngine(Settings indexSettings) {
         return ENGINE_HAVENASK.equals(ENGINE_TYPE_SETTING.get(indexSettings));
     }

--- a/modules/havenask-engine/src/test/java/org/havenask/engine/index/config/RealtimeInfoTests.java
+++ b/modules/havenask-engine/src/test/java/org/havenask/engine/index/config/RealtimeInfoTests.java
@@ -19,12 +19,13 @@ import org.havenask.test.HavenaskTestCase;
 public class RealtimeInfoTests extends HavenaskTestCase {
     // test for RealtimeInfo
     public void testRealtimeInfo() {
-        RealtimeInfo realtimeInfo = new RealtimeInfo("in0", "quickstart-events", "localhost:9092");
+        RealtimeInfo realtimeInfo = new RealtimeInfo("in0", "quickstart-events", "localhost:9092", 1000);
         assertEquals(
             realtimeInfo.toString(),
             "{\n"
                 + "\t\"bootstrap.servers\":\"localhost:9092\",\n"
                 + "\t\"data_table\":\"in0\",\n"
+                + "\t\"kafka_start_timestamp\":1000,\n"
                 + "\t\"module_name\":\"kafka\",\n"
                 + "\t\"module_path\":\"libbs_raw_doc_reader_plugin.so\",\n"
                 + "\t\"realtime_mode\":\"realtime_service_rawdoc_rt_build_mode\",\n"

--- a/modules/havenask-engine/src/test/java/org/havenask/engine/index/config/RealtimeInfoTests.java
+++ b/modules/havenask-engine/src/test/java/org/havenask/engine/index/config/RealtimeInfoTests.java
@@ -25,7 +25,7 @@ public class RealtimeInfoTests extends HavenaskTestCase {
             "{\n"
                 + "\t\"bootstrap.servers\":\"localhost:9092\",\n"
                 + "\t\"data_table\":\"in0\",\n"
-                + "\t\"kafka_start_timestamp\":1000,\n"
+                + "\t\"kafka_start_timestamp\":\"1000\",\n"
                 + "\t\"module_name\":\"kafka\",\n"
                 + "\t\"module_path\":\"libbs_raw_doc_reader_plugin.so\",\n"
                 + "\t\"realtime_mode\":\"realtime_service_rawdoc_rt_build_mode\",\n"


### PR DESCRIPTION
增加index.havenask.realtime.kafka_start_timestamp参数，单位是微秒，默认从最早时间开始消费kafka数据，配置了index.havenask.realtime.kafka_start_timestamp，则从指定时间开始消费。
havanask相关文档见：[实时功能使用文档](https://github.com/alibaba/havenask/wiki/%E5%AE%9E%E6%97%B6%E5%8A%9F%E8%83%BD%E4%BD%BF%E7%94%A8%E6%96%87%E6%A1%A3)