### PR TITLE
增加env plugin，支持在NodeEnvironment删除索引文件时，删除plugin的文件

### DIFF
--- a/modules/havenask-engine/src/main/java/org/havenask/engine/HavenaskEngineEnvironment.java
+++ b/modules/havenask-engine/src/main/java/org/havenask/engine/HavenaskEngineEnvironment.java
@@ -24,11 +24,16 @@ import org.havenask.common.io.PathUtils;
 import org.havenask.common.settings.Setting;
 import org.havenask.common.settings.Setting.Property;
 import org.havenask.common.settings.Settings;
+import org.havenask.core.internal.io.IOUtils;
 import org.havenask.env.Environment;
+import org.havenask.env.ShardLock;
+import org.havenask.index.Index;
+import org.havenask.index.IndexSettings;
+import org.havenask.plugins.NodeEnvironmentPlugin.CustomEnvironment;
 
 import static org.havenask.env.Environment.PATH_HOME_SETTING;
 
-public class HavenaskEngineEnvironment {
+public class HavenaskEngineEnvironment implements CustomEnvironment {
     public static final String DEFAULT_DATA_PATH = "data_havenask";
     public static final String HAVENASK_CONFIG_PATH = "config";
     public static final String HAVENASK_RUNTIMEDATA_PATH = "runtimedata";
@@ -108,5 +113,17 @@ public class HavenaskEngineEnvironment {
      */
     public Path getBsWorkPath() {
         return bsWorkPath;
+    }
+
+    @Override
+    public void deleteIndexDirectoryUnderLock(Index index, IndexSettings indexSettings) throws IOException {
+        Path indexDir = runtimedataPath.resolve(index.getName());
+        IOUtils.rm(indexDir);
+    }
+
+    @Override
+    public void deleteShardDirectoryUnderLock(ShardLock lock, IndexSettings indexSettings) throws IOException {
+        Path indexDir = runtimedataPath.resolve(lock.getShardId().getIndex().getName());
+        IOUtils.rm(indexDir);
     }
 }

--- a/modules/havenask-engine/src/main/java/org/havenask/engine/HavenaskEngineEnvironment.java
+++ b/modules/havenask-engine/src/main/java/org/havenask/engine/HavenaskEngineEnvironment.java
@@ -55,6 +55,8 @@ public class HavenaskEngineEnvironment implements CustomEnvironment {
     private final Path tablePath;
     private final Path bizsPath;
 
+    private NativeProcessControlService nativeProcessControlService;
+
     public HavenaskEngineEnvironment(final Environment environment, final Settings settings) {
         this.environment = environment;
         final Path homeFile = PathUtils.get(PATH_HOME_SETTING.get(settings)).normalize();
@@ -115,15 +117,27 @@ public class HavenaskEngineEnvironment implements CustomEnvironment {
         return bsWorkPath;
     }
 
+    public void setNativeProcessControlService(NativeProcessControlService nativeProcessControlService) {
+        this.nativeProcessControlService = nativeProcessControlService;
+    }
+
     @Override
     public void deleteIndexDirectoryUnderLock(Index index, IndexSettings indexSettings) throws IOException {
         Path indexDir = runtimedataPath.resolve(index.getName());
         IOUtils.rm(indexDir);
+        if (nativeProcessControlService != null) {
+            nativeProcessControlService.updateDataNodeTarget();
+            nativeProcessControlService.updateIngestNodeTarget();
+        }
     }
 
     @Override
     public void deleteShardDirectoryUnderLock(ShardLock lock, IndexSettings indexSettings) throws IOException {
         Path indexDir = runtimedataPath.resolve(lock.getShardId().getIndex().getName());
         IOUtils.rm(indexDir);
+        if (nativeProcessControlService != null) {
+            nativeProcessControlService.updateDataNodeTarget();
+            nativeProcessControlService.updateIngestNodeTarget();
+        }
     }
 }

--- a/modules/havenask-engine/src/main/java/org/havenask/engine/HavenaskEnginePlugin.java
+++ b/modules/havenask-engine/src/main/java/org/havenask/engine/HavenaskEnginePlugin.java
@@ -54,6 +54,7 @@ import org.havenask.index.shard.IndexSettingProvider;
 import org.havenask.plugins.ActionPlugin;
 import org.havenask.plugins.AnalysisPlugin;
 import org.havenask.plugins.EnginePlugin;
+import org.havenask.plugins.NodeEnvironmentPlugin;
 import org.havenask.plugins.Plugin;
 import org.havenask.plugins.SearchPlugin;
 import org.havenask.repositories.RepositoriesService;
@@ -66,7 +67,13 @@ import org.havenask.watcher.ResourceWatcherService;
 import static org.havenask.discovery.DiscoveryModule.DISCOVERY_TYPE_SETTING;
 import static org.havenask.discovery.DiscoveryModule.SINGLE_NODE_DISCOVERY_TYPE;
 
-public class HavenaskEnginePlugin extends Plugin implements EnginePlugin, AnalysisPlugin, ActionPlugin, SearchPlugin {
+public class HavenaskEnginePlugin extends Plugin
+    implements
+        EnginePlugin,
+        AnalysisPlugin,
+        ActionPlugin,
+        SearchPlugin,
+        NodeEnvironmentPlugin {
     private static Logger logger = LogManager.getLogger(HavenaskEnginePlugin.class);
     private final SetOnce<HavenaskEngineEnvironment> havenaskEngineEnvironmentSetOnce = new SetOnce<>();
     private final SetOnce<NativeProcessControlService> nativeProcessControlServiceSetOnce = new SetOnce<>();
@@ -130,15 +137,12 @@ public class HavenaskEnginePlugin extends Plugin implements EnginePlugin, Analys
         IndexNameExpressionResolver indexNameExpressionResolver,
         Supplier<RepositoriesService> repositoriesServiceSupplier
     ) {
-        HavenaskEngineEnvironment havenaskEngineEnvironment = new HavenaskEngineEnvironment(environment, clusterService.getSettings());
-        havenaskEngineEnvironmentSetOnce.set(havenaskEngineEnvironment);
-
         NativeProcessControlService nativeProcessControlService = new NativeProcessControlService(
             clusterService,
             threadPool,
             environment,
             nodeEnvironment,
-            havenaskEngineEnvironment
+            havenaskEngineEnvironmentSetOnce.get()
         );
         nativeProcessControlServiceSetOnce.set(nativeProcessControlService);
         HavenaskClient havenaskClient = new HavenaskHttpClient(nativeProcessControlService.getSearcherHttpPort());
@@ -180,5 +184,12 @@ public class HavenaskEnginePlugin extends Plugin implements EnginePlugin, Analys
     @Override
     public Collection<IndexSettingProvider> getAdditionalIndexSettingProviders() {
         return Arrays.asList(new HavenaskIndexSettingProvider());
+    }
+
+    @Override
+    public CustomEnvironment newEnvironment(final Environment environment, final Settings settings) {
+        HavenaskEngineEnvironment havenaskEngineEnvironment = new HavenaskEngineEnvironment(environment, settings);
+        havenaskEngineEnvironmentSetOnce.set(havenaskEngineEnvironment);
+        return havenaskEngineEnvironment;
     }
 }

--- a/modules/havenask-engine/src/main/java/org/havenask/engine/NativeProcessControlService.java
+++ b/modules/havenask-engine/src/main/java/org/havenask/engine/NativeProcessControlService.java
@@ -122,6 +122,7 @@ public class NativeProcessControlService extends AbstractLifecycleComponent {
         this.environment = environment;
         this.nodeEnvironment = nodeEnvironment;
         this.havenaskEngineEnvironment = havenaskEngineEnvironment;
+        havenaskEngineEnvironment.setNativeProcessControlService(this);
         this.searcherHttpPort = HAVENASK_SEARCHER_HTTP_PORT_SETTING.get(settings);
         this.searcherTcpPort = HAVENASK_SEARCHER_TCP_PORT_SETTING.get(settings);
         this.qrsHttpPort = HAVENASK_QRS_HTTP_PORT_SETTING.get(settings);

--- a/modules/havenask-engine/src/main/java/org/havenask/engine/index/engine/HavenaskEngine.java
+++ b/modules/havenask-engine/src/main/java/org/havenask/engine/index/engine/HavenaskEngine.java
@@ -100,8 +100,5 @@ public class HavenaskEngine extends InternalEngine {
     private synchronized void inactiveTable() throws IOException {
         BizConfigGenerator.removeBiz(engineConfig, env.getConfigPath());
         TableConfigGenerator.removeTable(engineConfig, env.getConfigPath());
-        // 更新配置表信息
-        nativeProcessControlService.updateDataNodeTarget();
-        nativeProcessControlService.updateIngestNodeTarget();
     }
 }

--- a/modules/havenask-engine/src/test/java/org/havenask/engine/HavenaskEngineEnvironmentTests.java
+++ b/modules/havenask-engine/src/test/java/org/havenask/engine/HavenaskEngineEnvironmentTests.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2021, Alibaba Group;
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.havenask.engine;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import junit.framework.TestCase;
+import org.havenask.common.settings.Settings;
+import org.havenask.discovery.DiscoveryModule;
+import org.havenask.env.Environment;
+import org.havenask.env.TestEnvironment;
+import org.havenask.index.Index;
+import org.havenask.index.shard.ShardId;
+import org.havenask.test.DummyShardLock;
+import org.havenask.test.HavenaskTestCase;
+
+import static org.havenask.discovery.DiscoveryModule.SINGLE_NODE_DISCOVERY_TYPE;
+
+public class HavenaskEngineEnvironmentTests extends HavenaskTestCase {
+    // test deleteIndexDirectoryUnderLock
+    public void testDeleteIndexDirectoryUnderLock() throws IOException {
+        Path workDir = createTempDir();
+        Settings settings = Settings.builder()
+            .put(Environment.PATH_HOME_SETTING.getKey(), workDir.toString())
+            .put(HavenaskEnginePlugin.HAVENASK_ENGINE_ENABLED_SETTING.getKey(), true)
+            .put(DiscoveryModule.DISCOVERY_TYPE_SETTING.getKey(), SINGLE_NODE_DISCOVERY_TYPE)
+            .build();
+        Path indexFile = workDir.resolve(HavenaskEngineEnvironment.DEFAULT_DATA_PATH)
+            .resolve(HavenaskEngineEnvironment.HAVENASK_RUNTIMEDATA_PATH)
+            .resolve("indexFile");
+        Files.createDirectories(indexFile);
+        TestCase.assertTrue(Files.exists(indexFile));
+        Environment environment = TestEnvironment.newEnvironment(settings);
+        HavenaskEngineEnvironment havenaskEngineEnvironment = new HavenaskEngineEnvironment(environment, settings);
+        havenaskEngineEnvironment.deleteIndexDirectoryUnderLock(new Index("indexFile", "indexFile"), null);
+        TestCase.assertFalse(Files.exists(indexFile));
+    }
+
+    // test deleteShardDirectoryUnderLock
+    public void testDeleteShardDirectoryUnderLock() throws IOException {
+        Path workDir = createTempDir();
+        Settings settings = Settings.builder()
+            .put(Environment.PATH_HOME_SETTING.getKey(), workDir.toString())
+            .put(HavenaskEnginePlugin.HAVENASK_ENGINE_ENABLED_SETTING.getKey(), true)
+            .put(DiscoveryModule.DISCOVERY_TYPE_SETTING.getKey(), SINGLE_NODE_DISCOVERY_TYPE)
+            .build();
+        Path indexFile = workDir.resolve(HavenaskEngineEnvironment.DEFAULT_DATA_PATH)
+            .resolve(HavenaskEngineEnvironment.HAVENASK_RUNTIMEDATA_PATH)
+            .resolve("indexFile");
+        Files.createDirectories(indexFile);
+        TestCase.assertTrue(Files.exists(indexFile));
+        Environment environment = TestEnvironment.newEnvironment(settings);
+        HavenaskEngineEnvironment havenaskEngineEnvironment = new HavenaskEngineEnvironment(environment, settings);
+        havenaskEngineEnvironment.deleteShardDirectoryUnderLock(new DummyShardLock(new ShardId("indexFile", "indexFile", 0)), null);
+        TestCase.assertFalse(Files.exists(indexFile));
+    }
+
+}

--- a/server/src/main/java/org/havenask/plugins/NodeEnvironmentPlugin.java
+++ b/server/src/main/java/org/havenask/plugins/NodeEnvironmentPlugin.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2021, Alibaba Group;
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.havenask.plugins;
+
+import java.io.IOException;
+
+import org.havenask.common.settings.Settings;
+import org.havenask.env.Environment;
+import org.havenask.env.ShardLock;
+import org.havenask.index.Index;
+import org.havenask.index.IndexSettings;
+
+public interface NodeEnvironmentPlugin {
+
+    interface CustomEnvironment {
+        /**
+         * Deletes the index directory for the given index under a lock.
+         * @param index the index to delete
+         * @param indexSettings settings for the index being deleted
+         */
+        void deleteIndexDirectoryUnderLock(Index index, IndexSettings indexSettings) throws IOException;
+
+        /**
+         * Deletes the shard directory for the given shard under a lock.
+         * @param lock the shard lock
+         * @param indexSettings settings for the index being deleted
+         */
+        void deleteShardDirectoryUnderLock(ShardLock lock, IndexSettings indexSettings) throws IOException;
+    }
+
+    CustomEnvironment newEnvironment(final Environment environment, final Settings settings);
+}

--- a/server/src/main/java/org/havenask/plugins/NodeEnvironmentPlugin.java
+++ b/server/src/main/java/org/havenask/plugins/NodeEnvironmentPlugin.java
@@ -40,5 +40,5 @@ public interface NodeEnvironmentPlugin {
         void deleteShardDirectoryUnderLock(ShardLock lock, IndexSettings indexSettings) throws IOException;
     }
 
-    CustomEnvironment newEnvironment(final Environment environment, final Settings settings);
+    CustomEnvironment newEnvironment(Environment environment, Settings settings);
 }


### PR DESCRIPTION
增加NodeEnvironmentPlugin，在NodeEnvironment执行deleteIndexDirectoryUnderLock和deleteShardDirectoryUnderLock时调用plugin的deleteIndexDirectoryUnderLock和deleteShardDirectoryUnderLock方法