### PR TITLE
创建索引，默认配置改为不等待shard active

### DIFF
--- a/server/src/main/java/org/havenask/rest/action/admin/indices/RestCreateIndexAction.java
+++ b/server/src/main/java/org/havenask/rest/action/admin/indices/RestCreateIndexAction.java
@@ -94,6 +94,15 @@ public class RestCreateIndexAction extends BaseRestHandler {
 
         createIndexRequest.timeout(request.paramAsTime("timeout", createIndexRequest.timeout()));
         createIndexRequest.masterNodeTimeout(request.paramAsTime("master_timeout", createIndexRequest.masterNodeTimeout()));
+
+        String waitForActiveShards = request.param("wait_for_active_shards");
+        if (waitForActiveShards == null) {
+            createIndexRequest.waitForActiveShards(ActiveShardCount.NONE);
+
+        } else {
+            createIndexRequest.waitForActiveShards(ActiveShardCount.parseString(waitForActiveShards));
+        }
+
         createIndexRequest.waitForActiveShards(ActiveShardCount.parseString(request.param("wait_for_active_shards")));
         return channel -> client.admin().indices().create(createIndexRequest, new RestToXContentListener<>(channel));
     }


### PR DESCRIPTION
由于havenask创建数据表的耗时比较长，很容易触发创建索引timeout。
默认改为不等待shard active可以避免该问题。
修改rest层的配置，测试用例能全部通过