### PR TITLE
修复havenask sql kvpair参数异常

### DIFF
--- a/modules/havenask-engine/src/main/java/org/havenask/engine/rpc/http/QrsHttpClient.java
+++ b/modules/havenask-engine/src/main/java/org/havenask/engine/rpc/http/QrsHttpClient.java
@@ -33,10 +33,11 @@ public class QrsHttpClient extends HavenaskHttpClient implements QrsClient {
     @Override
     public QrsSqlResponse executeSql(QrsSqlRequest qrsSqlRequest) throws IOException {
         HttpUrl.Builder urlBuilder = HttpUrl.parse(url + SQL_URL).newBuilder();
-        urlBuilder.addQueryParameter("query", qrsSqlRequest.getSql());
+        String query = qrsSqlRequest.getSql();
         if (qrsSqlRequest.getKvpair() != null) {
-            urlBuilder.addQueryParameter("kvpair", qrsSqlRequest.getKvpair());
+            query += "&&kvpair=" + qrsSqlRequest.getKvpair();
         }
+        urlBuilder.addQueryParameter("query", query);
         String url = urlBuilder.build().toString();
         Request request = new Request.Builder().url(url).build();
         Response response = client.newCall(request).execute();


### PR DESCRIPTION
修复havenask sql kvpair参数异常，正确传递方式示例为：query=SELECT brand, COUNT(*) FROM phone &&kvpair=trace:INFO
其中就一个query参数