### PR TITLE
修复创建索引waitForActiveShards设置未生效

### DIFF
--- a/server/src/main/java/org/havenask/rest/action/admin/indices/RestCreateIndexAction.java
+++ b/server/src/main/java/org/havenask/rest/action/admin/indices/RestCreateIndexAction.java
@@ -95,10 +95,10 @@ public class RestCreateIndexAction extends BaseRestHandler {
         createIndexRequest.timeout(request.paramAsTime("timeout", createIndexRequest.timeout()));
         createIndexRequest.masterNodeTimeout(request.paramAsTime("master_timeout", createIndexRequest.masterNodeTimeout()));
 
+        String engine = createIndexRequest.settings().get("index.engine");
         String waitForActiveShards = request.param("wait_for_active_shards");
-        if (waitForActiveShards == null) {
+        if (waitForActiveShards == null && (engine != null && engine.equals("havenask"))) {
             createIndexRequest.waitForActiveShards(ActiveShardCount.NONE);
-
         } else {
             createIndexRequest.waitForActiveShards(ActiveShardCount.parseString(waitForActiveShards));
         }

--- a/server/src/main/java/org/havenask/rest/action/admin/indices/RestCreateIndexAction.java
+++ b/server/src/main/java/org/havenask/rest/action/admin/indices/RestCreateIndexAction.java
@@ -102,8 +102,6 @@ public class RestCreateIndexAction extends BaseRestHandler {
         } else {
             createIndexRequest.waitForActiveShards(ActiveShardCount.parseString(waitForActiveShards));
         }
-
-        createIndexRequest.waitForActiveShards(ActiveShardCount.parseString(request.param("wait_for_active_shards")));
         return channel -> client.admin().indices().create(createIndexRequest, new RestToXContentListener<>(channel));
     }
 


### PR DESCRIPTION
修复 [#37](https://github.com/alibaba/havenask-federation/pull/37) bug，多设置了createIndexRequest.waitForActiveShards，并只有havenask索引才默认设置为None