### PR TITLE
Revert "增加默认参数index.mapper.dynamic，设置为false，不支持动态mapping (#40)"

### DIFF
--- a/modules/havenask-engine/src/main/java/org/havenask/engine/HavenaskIndexSettingProvider.java
+++ b/modules/havenask-engine/src/main/java/org/havenask/engine/HavenaskIndexSettingProvider.java
@@ -19,7 +19,6 @@ import org.havenask.engine.index.engine.EngineSettings;
 import org.havenask.index.shard.IndexSettingProvider;
 
 import static org.havenask.cluster.metadata.IndexMetadata.SETTING_NUMBER_OF_REPLICAS;
-import static org.havenask.index.mapper.MapperService.INDEX_MAPPER_DYNAMIC_SETTING;
 
 public class HavenaskIndexSettingProvider implements IndexSettingProvider {
     public Settings getAdditionalIndexSettings(String indexName, boolean isDataStreamIndex, Settings templateAndRequestSettings) {
@@ -28,11 +27,7 @@ public class HavenaskIndexSettingProvider implements IndexSettingProvider {
             if (replica != 0) {
                 throw new IllegalArgumentException("havenask engine only support 0 replica");
             }
-            boolean mappingDynamic = templateAndRequestSettings.getAsBoolean(INDEX_MAPPER_DYNAMIC_SETTING.getKey(), false);
-            if (mappingDynamic) {
-                throw new IllegalArgumentException("havenask engine only support mapping dynamic false");
-            }
-            return Settings.builder().put(SETTING_NUMBER_OF_REPLICAS, 0).put(INDEX_MAPPER_DYNAMIC_SETTING.getKey(), false).build();
+            return Settings.builder().put(SETTING_NUMBER_OF_REPLICAS, 0).build();
         } else {
             return Settings.EMPTY;
         }

--- a/modules/havenask-engine/src/test/java/org/havenask/engine/HavenaskIndexSettingProviderTests.java
+++ b/modules/havenask-engine/src/test/java/org/havenask/engine/HavenaskIndexSettingProviderTests.java
@@ -26,9 +26,6 @@ public class HavenaskIndexSettingProviderTests extends HavenaskTestCase {
         Settings settings = provider.getAdditionalIndexSettings("test", false, Settings.builder().put("index.engine", "havenask").build());
         int replicas = settings.getAsInt(SETTING_NUMBER_OF_REPLICAS, 2);
         assertEquals(0, replicas);
-        // assert mappingDynamic
-        boolean mappingDynamic = settings.getAsBoolean("index.mapper.dynamic", true);
-        assertEquals(false, mappingDynamic);
     }
 
     // test for havenask engine only support 0 replica
@@ -67,20 +64,5 @@ public class HavenaskIndexSettingProviderTests extends HavenaskTestCase {
         Settings settings = provider.getAdditionalIndexSettings("test", false, Settings.builder().build());
         int replicas = settings.getAsInt(SETTING_NUMBER_OF_REPLICAS, 2);
         assertEquals(2, replicas);
-    }
-
-    // test invalid mappingDynamic
-    public void testGetAdditionalIndexSettingsWithInvalidMappingDynamic() {
-        HavenaskIndexSettingProvider provider = new HavenaskIndexSettingProvider();
-        try {
-            provider.getAdditionalIndexSettings(
-                "test",
-                false,
-                Settings.builder().put("index.engine", "havenask").put("index.mapper.dynamic", true).build()
-            );
-            fail("should throw IllegalArgumentException");
-        } catch (IllegalArgumentException e) {
-            assertEquals("havenask engine only support mapping dynamic false", e.getMessage());
-        }
     }
 }


### PR DESCRIPTION
This reverts commit ab7cb9c7c67675b96c702ca189bb82d8dd42b1ef.

index.mapper.dynamic参数已经废弃，用来控制新增type，而不是field，所以功能上有歧义，而且目前只支持单type，所以revert该修改