### PR TITLE
创建、删除索引和havenask的交互重构

### DIFF
--- a/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/HavenaskEngineEnvironment.java
+++ b/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/HavenaskEngineEnvironment.java
@@ -25,6 +25,8 @@ import org.havenask.common.settings.Setting;
 import org.havenask.common.settings.Setting.Property;
 import org.havenask.common.settings.Settings;
 import org.havenask.core.internal.io.IOUtils;
+import org.havenask.engine.index.config.generator.BizConfigGenerator;
+import org.havenask.engine.index.config.generator.TableConfigGenerator;
 import org.havenask.env.Environment;
 import org.havenask.env.ShardLock;
 import org.havenask.index.Index;
@@ -123,6 +125,8 @@ public class HavenaskEngineEnvironment implements CustomEnvironment {
 
     @Override
     public void deleteIndexDirectoryUnderLock(Index index, IndexSettings indexSettings) throws IOException {
+        BizConfigGenerator.removeBiz(index.getName(), configPath);
+        TableConfigGenerator.removeTable(index.getName(), configPath);
         Path indexDir = runtimedataPath.resolve(index.getName());
         IOUtils.rm(indexDir);
         if (nativeProcessControlService != null) {

--- a/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/HavenaskEngineEnvironment.java
+++ b/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/HavenaskEngineEnvironment.java
@@ -137,11 +137,6 @@ public class HavenaskEngineEnvironment implements CustomEnvironment {
 
     @Override
     public void deleteShardDirectoryUnderLock(ShardLock lock, IndexSettings indexSettings) throws IOException {
-        Path indexDir = runtimedataPath.resolve(lock.getShardId().getIndex().getName());
-        IOUtils.rm(indexDir);
-        if (nativeProcessControlService != null) {
-            nativeProcessControlService.updateDataNodeTarget();
-            nativeProcessControlService.updateIngestNodeTarget();
-        }
+        // TODO 删除shard先不做处理,在删除index的时候处理,后续支持多shard后再处理
     }
 }

--- a/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/HavenaskEnginePlugin.java
+++ b/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/HavenaskEnginePlugin.java
@@ -41,6 +41,7 @@ import org.havenask.common.settings.Setting.Property;
 import org.havenask.common.settings.Settings;
 import org.havenask.common.settings.SettingsFilter;
 import org.havenask.common.xcontent.NamedXContentRegistry;
+import org.havenask.engine.index.HavenaskIndexEventListener;
 import org.havenask.engine.index.engine.EngineSettings;
 import org.havenask.engine.index.engine.HavenaskEngine;
 import org.havenask.engine.rpc.HavenaskClient;
@@ -53,6 +54,7 @@ import org.havenask.engine.search.rest.RestHavenaskSqlAction;
 import org.havenask.engine.search.rest.RestHavenaskSqlClientInfoAction;
 import org.havenask.env.Environment;
 import org.havenask.env.NodeEnvironment;
+import org.havenask.index.IndexModule;
 import org.havenask.index.IndexSettings;
 import org.havenask.index.engine.EngineFactory;
 import org.havenask.index.shard.IndexMappingProvider;
@@ -221,5 +223,12 @@ public class HavenaskEnginePlugin extends Plugin
         HavenaskEngineEnvironment havenaskEngineEnvironment = new HavenaskEngineEnvironment(environment, settings);
         havenaskEngineEnvironmentSetOnce.set(havenaskEngineEnvironment);
         return havenaskEngineEnvironment;
+    }
+
+    @Override
+    public void onIndexModule(IndexModule indexModule) {
+        if (EngineSettings.isHavenaskEngine(indexModule.getSettings())) {
+            indexModule.addIndexEventListener(new HavenaskIndexEventListener(havenaskEngineEnvironmentSetOnce.get()));
+        }
     }
 }

--- a/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/index/HavenaskIndexEventListener.java
+++ b/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/index/HavenaskIndexEventListener.java
@@ -32,7 +32,7 @@ public class HavenaskIndexEventListener implements IndexEventListener {
     }
 
     @Override
-    public void afterIndexCreated(IndexService indexService) {
+    public void afterIndexMappingUpdate(IndexService indexService) {
         try {
             BizConfigGenerator.generateBiz(
                 indexService.index().getName(),

--- a/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/index/HavenaskIndexEventListener.java
+++ b/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/index/HavenaskIndexEventListener.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2021, Alibaba Group;
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.havenask.engine.index;
+
+import java.io.IOException;
+
+import org.havenask.HavenaskException;
+import org.havenask.engine.HavenaskEngineEnvironment;
+import org.havenask.engine.index.config.generator.BizConfigGenerator;
+import org.havenask.engine.index.config.generator.TableConfigGenerator;
+import org.havenask.index.IndexService;
+import org.havenask.index.shard.IndexEventListener;
+
+public class HavenaskIndexEventListener implements IndexEventListener {
+
+    private final HavenaskEngineEnvironment env;
+
+    public HavenaskIndexEventListener(HavenaskEngineEnvironment env) {
+        this.env = env;
+    }
+
+    @Override
+    public void afterIndexCreated(IndexService indexService) {
+        try {
+            BizConfigGenerator.generateBiz(
+                indexService.index().getName(),
+                indexService.getIndexSettings(),
+                indexService.mapperService(),
+                env.getConfigPath()
+            );
+            TableConfigGenerator.generateTable(
+                indexService.index().getName(),
+                indexService.getIndexSettings(),
+                indexService.mapperService(),
+                env.getConfigPath()
+            );
+        } catch (IOException e) {
+            throw new HavenaskException("generate havenask config error", e);
+        }
+    }
+}

--- a/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/index/engine/SchemaGenerate.java
+++ b/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/index/engine/SchemaGenerate.java
@@ -33,7 +33,6 @@ import org.havenask.common.io.Streams;
 import org.havenask.engine.index.config.Analyzers;
 import org.havenask.engine.index.config.Schema;
 import org.havenask.index.IndexSettings;
-import org.havenask.index.engine.EngineConfig;
 import org.havenask.index.mapper.IdFieldMapper;
 import org.havenask.index.mapper.MappedFieldType;
 import org.havenask.index.mapper.MapperService;
@@ -77,14 +76,6 @@ public class SchemaGenerate {
     );
 
     Logger logger = LogManager.getLogger(SchemaGenerate.class);
-
-    public Schema getSchema(EngineConfig engineConfig) throws IOException {
-        return getSchema(
-            engineConfig.getShardId().getIndexName(),
-            engineConfig.getIndexSettings(),
-            engineConfig.getCodecService().getMapperService()
-        );
-    }
 
     // generate index schema from mapping
     public Schema getSchema(String table, IndexSettings indexSettings, MapperService mapperService) throws IOException {

--- a/elastic-fed/modules/havenask-engine/src/test/java/org/havenask/engine/HavenaskEngineEnvironmentTests.java
+++ b/elastic-fed/modules/havenask-engine/src/test/java/org/havenask/engine/HavenaskEngineEnvironmentTests.java
@@ -15,12 +15,15 @@
 package org.havenask.engine;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 
 import junit.framework.TestCase;
 import org.havenask.common.settings.Settings;
 import org.havenask.discovery.DiscoveryModule;
+import org.havenask.engine.index.config.ZoneBiz;
 import org.havenask.env.Environment;
 import org.havenask.env.TestEnvironment;
 import org.havenask.index.Index;
@@ -29,6 +32,9 @@ import org.havenask.test.DummyShardLock;
 import org.havenask.test.HavenaskTestCase;
 
 import static org.havenask.discovery.DiscoveryModule.SINGLE_NODE_DISCOVERY_TYPE;
+import static org.havenask.engine.index.config.generator.BizConfigGenerator.BIZ_DIR;
+import static org.havenask.engine.index.config.generator.BizConfigGenerator.DEFAULT_BIZ_CONFIG;
+import static org.havenask.engine.index.config.generator.TableConfigGenerator.TABLE_DIR;
 
 public class HavenaskEngineEnvironmentTests extends HavenaskTestCase {
     // test deleteIndexDirectoryUnderLock
@@ -44,6 +50,18 @@ public class HavenaskEngineEnvironmentTests extends HavenaskTestCase {
             .resolve("indexFile");
         Files.createDirectories(indexFile);
         TestCase.assertTrue(Files.exists(indexFile));
+
+        Path configPath = workDir.resolve(HavenaskEngineEnvironment.DEFAULT_DATA_PATH)
+            .resolve(HavenaskEngineEnvironment.HAVENASK_CONFIG_PATH);
+        Files.createDirectories(configPath.resolve(TABLE_DIR).resolve("0"));
+        Files.createDirectories(configPath.resolve(BIZ_DIR).resolve("0"));
+        Files.createDirectories(configPath.resolve(BIZ_DIR).resolve("0").resolve("zones").resolve("general"));
+        ZoneBiz zoneBiz = new ZoneBiz();
+        Files.write(
+            configPath.resolve(BIZ_DIR).resolve("0").resolve(DEFAULT_BIZ_CONFIG),
+            zoneBiz.toString().getBytes(StandardCharsets.UTF_8),
+            StandardOpenOption.CREATE
+        );
         Environment environment = TestEnvironment.newEnvironment(settings);
         HavenaskEngineEnvironment havenaskEngineEnvironment = new HavenaskEngineEnvironment(environment, settings);
         havenaskEngineEnvironment.deleteIndexDirectoryUnderLock(new Index("indexFile", "indexFile"), null);

--- a/elastic-fed/modules/havenask-engine/src/test/java/org/havenask/engine/HavenaskEngineEnvironmentTests.java
+++ b/elastic-fed/modules/havenask-engine/src/test/java/org/havenask/engine/HavenaskEngineEnvironmentTests.java
@@ -27,8 +27,6 @@ import org.havenask.engine.index.config.ZoneBiz;
 import org.havenask.env.Environment;
 import org.havenask.env.TestEnvironment;
 import org.havenask.index.Index;
-import org.havenask.index.shard.ShardId;
-import org.havenask.test.DummyShardLock;
 import org.havenask.test.HavenaskTestCase;
 
 import static org.havenask.discovery.DiscoveryModule.SINGLE_NODE_DISCOVERY_TYPE;
@@ -67,24 +65,4 @@ public class HavenaskEngineEnvironmentTests extends HavenaskTestCase {
         havenaskEngineEnvironment.deleteIndexDirectoryUnderLock(new Index("indexFile", "indexFile"), null);
         TestCase.assertFalse(Files.exists(indexFile));
     }
-
-    // test deleteShardDirectoryUnderLock
-    public void testDeleteShardDirectoryUnderLock() throws IOException {
-        Path workDir = createTempDir();
-        Settings settings = Settings.builder()
-            .put(Environment.PATH_HOME_SETTING.getKey(), workDir.toString())
-            .put(HavenaskEnginePlugin.HAVENASK_ENGINE_ENABLED_SETTING.getKey(), true)
-            .put(DiscoveryModule.DISCOVERY_TYPE_SETTING.getKey(), SINGLE_NODE_DISCOVERY_TYPE)
-            .build();
-        Path indexFile = workDir.resolve(HavenaskEngineEnvironment.DEFAULT_DATA_PATH)
-            .resolve(HavenaskEngineEnvironment.HAVENASK_RUNTIMEDATA_PATH)
-            .resolve("indexFile");
-        Files.createDirectories(indexFile);
-        TestCase.assertTrue(Files.exists(indexFile));
-        Environment environment = TestEnvironment.newEnvironment(settings);
-        HavenaskEngineEnvironment havenaskEngineEnvironment = new HavenaskEngineEnvironment(environment, settings);
-        havenaskEngineEnvironment.deleteShardDirectoryUnderLock(new DummyShardLock(new ShardId("indexFile", "indexFile", 0)), null);
-        TestCase.assertFalse(Files.exists(indexFile));
-    }
-
 }

--- a/elastic-fed/modules/havenask-engine/src/test/java/org/havenask/engine/index/config/generator/BizConfigGeneratorTests.java
+++ b/elastic-fed/modules/havenask-engine/src/test/java/org/havenask/engine/index/config/generator/BizConfigGeneratorTests.java
@@ -25,13 +25,9 @@ import org.havenask.Version;
 import org.havenask.cluster.metadata.IndexMetadata;
 import org.havenask.common.settings.Settings;
 import org.havenask.engine.index.config.ZoneBiz;
-import org.havenask.index.Index;
 import org.havenask.index.IndexSettings;
-import org.havenask.index.codec.CodecService;
-import org.havenask.index.engine.EngineConfig;
 import org.havenask.index.mapper.MapperService;
 import org.havenask.index.mapper.MapperServiceTestCase;
-import org.havenask.index.shard.ShardId;
 
 import static org.havenask.engine.index.config.generator.BizConfigGenerator.BIZ_DIR;
 import static org.havenask.engine.index.config.generator.BizConfigGenerator.CLUSTER_DIR;
@@ -41,8 +37,6 @@ import static org.havenask.engine.index.config.generator.BizConfigGenerator.DATA
 import static org.havenask.engine.index.config.generator.BizConfigGenerator.DEFAULT_BIZ_CONFIG;
 import static org.havenask.engine.index.config.generator.BizConfigGenerator.SCHEMAS_DIR;
 import static org.havenask.engine.index.config.generator.BizConfigGenerator.SCHEMAS_FILE_SUFFIX;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class BizConfigGeneratorTests extends MapperServiceTestCase {
     public void testBasic() throws IOException {
@@ -54,12 +48,6 @@ public class BizConfigGeneratorTests extends MapperServiceTestCase {
             .build();
         IndexSettings settings = new IndexSettings(build, Settings.EMPTY);
         MapperService mapperService = createMapperService(fieldMapping(b -> b.field("type", "keyword")));
-        EngineConfig engineConfig = mock(EngineConfig.class);
-        CodecService codecService = mock(CodecService.class);
-        when(codecService.getMapperService()).thenReturn(mapperService);
-        when(engineConfig.getShardId()).thenReturn(new ShardId(new Index(indexName, randomAlphaOfLength(5)), 0));
-        when(engineConfig.getCodecService()).thenReturn(codecService);
-        when(engineConfig.getIndexSettings()).thenReturn(settings);
         Path configPath = createTempDir();
         Files.createDirectories(configPath.resolve(BIZ_DIR).resolve("0").resolve(CLUSTER_DIR));
         Files.createDirectories(configPath.resolve(BIZ_DIR).resolve("0").resolve(SCHEMAS_DIR));
@@ -71,7 +59,7 @@ public class BizConfigGeneratorTests extends MapperServiceTestCase {
             zoneBiz.toString().getBytes(StandardCharsets.UTF_8),
             StandardOpenOption.CREATE
         );
-        BizConfigGenerator bizConfigGenerator = new BizConfigGenerator(engineConfig, configPath);
+        BizConfigGenerator bizConfigGenerator = new BizConfigGenerator(indexName, settings, mapperService, configPath);
         bizConfigGenerator.generate();
 
         {

--- a/elastic-fed/modules/havenask-engine/src/test/java/org/havenask/engine/index/config/generator/TableConfigGeneratorTests.java
+++ b/elastic-fed/modules/havenask-engine/src/test/java/org/havenask/engine/index/config/generator/TableConfigGeneratorTests.java
@@ -22,13 +22,9 @@ import java.util.Locale;
 import org.havenask.Version;
 import org.havenask.cluster.metadata.IndexMetadata;
 import org.havenask.common.settings.Settings;
-import org.havenask.index.Index;
 import org.havenask.index.IndexSettings;
-import org.havenask.index.codec.CodecService;
-import org.havenask.index.engine.EngineConfig;
 import org.havenask.index.mapper.MapperService;
 import org.havenask.index.mapper.MapperServiceTestCase;
-import org.havenask.index.shard.ShardId;
 
 import static org.havenask.engine.index.config.generator.BizConfigGenerator.DATA_TABLES_DIR;
 import static org.havenask.engine.index.config.generator.BizConfigGenerator.DATA_TABLES_FILE_SUFFIX;
@@ -37,8 +33,6 @@ import static org.havenask.engine.index.config.generator.BizConfigGenerator.SCHE
 import static org.havenask.engine.index.config.generator.TableConfigGenerator.CLUSTER_DIR;
 import static org.havenask.engine.index.config.generator.TableConfigGenerator.CLUSTER_FILE_SUFFIX;
 import static org.havenask.engine.index.config.generator.TableConfigGenerator.TABLE_DIR;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class TableConfigGeneratorTests extends MapperServiceTestCase {
     public void testBasic() throws IOException {
@@ -50,17 +44,11 @@ public class TableConfigGeneratorTests extends MapperServiceTestCase {
             .build();
         IndexSettings settings = new IndexSettings(build, Settings.EMPTY);
         MapperService mapperService = createMapperService(fieldMapping(b -> b.field("type", "keyword")));
-        EngineConfig engineConfig = mock(EngineConfig.class);
-        CodecService codecService = mock(CodecService.class);
-        when(codecService.getMapperService()).thenReturn(mapperService);
-        when(engineConfig.getShardId()).thenReturn(new ShardId(new Index(indexName, randomAlphaOfLength(5)), 0));
-        when(engineConfig.getCodecService()).thenReturn(codecService);
-        when(engineConfig.getIndexSettings()).thenReturn(settings);
         Path configPath = createTempDir();
         Files.createDirectories(configPath.resolve(TABLE_DIR).resolve("0").resolve(CLUSTER_DIR));
         Files.createDirectories(configPath.resolve(TABLE_DIR).resolve("0").resolve(SCHEMAS_DIR));
         Files.createDirectories(configPath.resolve(TABLE_DIR).resolve("0").resolve(DATA_TABLES_DIR));
-        TableConfigGenerator tableConfigGenerator = new TableConfigGenerator(engineConfig, configPath);
+        TableConfigGenerator tableConfigGenerator = new TableConfigGenerator(indexName, settings, mapperService, configPath);
         tableConfigGenerator.generate();
 
         {

--- a/elastic-fed/server/src/main/java/org/havenask/index/CompositeIndexEventListener.java
+++ b/elastic-fed/server/src/main/java/org/havenask/index/CompositeIndexEventListener.java
@@ -192,6 +192,18 @@ final class CompositeIndexEventListener implements IndexEventListener {
     }
 
     @Override
+    public void afterIndexMappingUpdate(IndexService indexService) {
+        for (IndexEventListener listener : listeners) {
+            try {
+                listener.afterIndexMappingUpdate(indexService);
+            } catch (Exception e) {
+                logger.warn("failed to invoke after index mapping update callback", e);
+                throw e;
+            }
+        }
+    }
+
+    @Override
     public void beforeIndexShardCreated(ShardId shardId, Settings indexSettings) {
         for (IndexEventListener listener : listeners) {
             try {

--- a/elastic-fed/server/src/main/java/org/havenask/index/codec/CodecService.java
+++ b/elastic-fed/server/src/main/java/org/havenask/index/codec/CodecService.java
@@ -58,7 +58,6 @@ import java.util.Map;
 public class CodecService {
 
     private final Map<String, Codec> codecs;
-    private final MapperService mapperService;
 
     public static final String DEFAULT_CODEC = "default";
     public static final String BEST_COMPRESSION_CODEC = "best_compression";
@@ -66,7 +65,6 @@ public class CodecService {
     public static final String LUCENE_DEFAULT_CODEC = "lucene_default";
 
     public CodecService(@Nullable MapperService mapperService, Logger logger) {
-        this.mapperService = mapperService;
         final MapBuilder<String, Codec> codecs = MapBuilder.<String, Codec>newMapBuilder();
         if (mapperService == null) {
             codecs.put(DEFAULT_CODEC, new Lucene87Codec());
@@ -97,9 +95,5 @@ public class CodecService {
      */
     public String[] availableCodecs() {
         return codecs.keySet().toArray(new String[0]);
-    }
-
-    public MapperService getMapperService() {
-        return mapperService;
     }
 }

--- a/elastic-fed/server/src/main/java/org/havenask/index/engine/EngineConfig.java
+++ b/elastic-fed/server/src/main/java/org/havenask/index/engine/EngineConfig.java
@@ -73,7 +73,7 @@ import java.util.function.Supplier;
  * Once {@link Engine} has been created with this object, changes to this
  * object will affect the {@link Engine} instance.
  */
-public class EngineConfig {
+public final class EngineConfig {
     private final ShardId shardId;
     private final IndexSettings indexSettings;
     private final ByteSizeValue indexingBufferSize;
@@ -241,17 +241,7 @@ public class EngineConfig {
     public Codec getCodec() {
         return codecService.codec(codecName);
     }
-
-    /**
-     * Returns the {@link CodecService} used in the engines
-     * <p>
-     *     Note: this settings is only read on startup.
-     * </p>
-     */
-    public CodecService getCodecService() {
-        return codecService;
-    }
-
+    
     /**
      * Returns a thread-pool mainly used to get estimated time stamps from
      * {@link org.havenask.threadpool.ThreadPool#relativeTimeInMillis()} and to schedule

--- a/elastic-fed/server/src/main/java/org/havenask/index/engine/EngineConfig.java
+++ b/elastic-fed/server/src/main/java/org/havenask/index/engine/EngineConfig.java
@@ -241,7 +241,7 @@ public final class EngineConfig {
     public Codec getCodec() {
         return codecService.codec(codecName);
     }
-    
+
     /**
      * Returns a thread-pool mainly used to get estimated time stamps from
      * {@link org.havenask.threadpool.ThreadPool#relativeTimeInMillis()} and to schedule

--- a/elastic-fed/server/src/main/java/org/havenask/index/engine/InternalEngine.java
+++ b/elastic-fed/server/src/main/java/org/havenask/index/engine/InternalEngine.java
@@ -2237,7 +2237,7 @@ public class InternalEngine extends Engine {
      * is failed.
      */
     @Override
-    protected void closeNoLock(String reason, CountDownLatch closedLatch) {
+    protected final void closeNoLock(String reason, CountDownLatch closedLatch) {
         if (isClosed.compareAndSet(false, true)) {
             assert rwl.isWriteLockedByCurrentThread() || failEngineLock.isHeldByCurrentThread() :
                 "Either the write lock must be held or the engine must be currently be failing itself";

--- a/elastic-fed/server/src/main/java/org/havenask/index/shard/IndexEventListener.java
+++ b/elastic-fed/server/src/main/java/org/havenask/index/shard/IndexEventListener.java
@@ -127,6 +127,13 @@ public interface IndexEventListener {
     }
 
     /**
+     * Called after the index mapping has been updated.
+     */
+    default void afterIndexMappingUpdate(IndexService indexService) {
+
+    }
+
+    /**
      * Called before the index get closed.
      *
      * @param indexService The index service

--- a/elastic-fed/server/src/main/java/org/havenask/indices/cluster/IndicesClusterStateService.java
+++ b/elastic-fed/server/src/main/java/org/havenask/indices/cluster/IndicesClusterStateService.java
@@ -510,6 +510,8 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
                             indexMetadata.getIndexUUID(), state.nodes().getLocalNodeId())
                     );
                 }
+                IndexService realIndexService = (IndexService) indexService;
+                realIndexService.getIndexEventListener().afterIndexMappingUpdate(realIndexService);
             } catch (Exception e) {
                 final String failShardReason;
                 if (indexService == null) {

--- a/elastic-fed/server/src/main/java/org/havenask/indices/cluster/IndicesClusterStateService.java
+++ b/elastic-fed/server/src/main/java/org/havenask/indices/cluster/IndicesClusterStateService.java
@@ -510,8 +510,10 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
                             indexMetadata.getIndexUUID(), state.nodes().getLocalNodeId())
                     );
                 }
-                IndexService realIndexService = (IndexService) indexService;
-                realIndexService.getIndexEventListener().afterIndexMappingUpdate(realIndexService);
+                if (indexService instanceof IndexService) {
+                    IndexService realIndexService = (IndexService) indexService;
+                    realIndexService.getIndexEventListener().afterIndexMappingUpdate(realIndexService);
+                }
             } catch (Exception e) {
                 final String failShardReason;
                 if (indexService == null) {


### PR DESCRIPTION
创建havenask的配置从shard级别在engine层创建，改成了在index级别创建。
删除havenask的配置从shard级别在engine层close时删除，改成了在索引删除时删除配置。
这样修改完成后，仍然无法支持open、close接口，后续需要针对性开发支持open、close接口。