### PR TITLE
支持异步调用target更新命令， 防止阻塞task线程

### DIFF
--- a/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/HavenaskEngineEnvironment.java
+++ b/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/HavenaskEngineEnvironment.java
@@ -126,8 +126,7 @@ public class HavenaskEngineEnvironment implements CustomEnvironment {
         Path indexDir = runtimedataPath.resolve(index.getName());
         IOUtils.rm(indexDir);
         if (nativeProcessControlService != null) {
-            nativeProcessControlService.updateDataNodeTarget();
-            nativeProcessControlService.updateIngestNodeTarget();
+            nativeProcessControlService.asyncUpdateTarget();
         }
     }
 

--- a/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/NativeProcessControlService.java
+++ b/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/NativeProcessControlService.java
@@ -374,13 +374,6 @@ public class NativeProcessControlService extends AbstractLifecycleComponent {
         return qrsHttpPort;
     }
 
-    public void updateDataNodeTarget() {
-        if (isDataNode && running) {
-            // 更新datanode searcher的target
-            runScript(updateSearcherCommand);
-        }
-    }
-
     public void startBsJob(String indexName, String realtimeInfo) {
         if (isDataNode) {
             // 启动bs job
@@ -397,10 +390,35 @@ public class NativeProcessControlService extends AbstractLifecycleComponent {
         }
     }
 
-    public synchronized void updateIngestNodeTarget() {
+    public void updateDataNodeTarget() {
+        if (isDataNode && running) {
+            // 更新datanode searcher的target
+            runScript(updateSearcherCommand);
+        }
+    }
+
+    public void updateIngestNodeTarget() {
         if (isIngestNode && running) {
             // 更新ingestnode qrs的target
             runScript(updateQrsCommand);
+        }
+    }
+
+    /**
+     * 异步更新target
+     */
+    public void asyncUpdateTarget() {
+        if (running && (isDataNode || isIngestNode)) {
+            threadPool.executor(HavenaskEnginePlugin.HAVENASK_THREAD_POOL_NAME).execute(() -> {
+                if (isDataNode) {
+                    // 更新datanode searcher的target
+                    runScript(updateSearcherCommand);
+                }
+                if (isIngestNode) {
+                    // 更新ingestnode qrs的target
+                    runScript(updateQrsCommand);
+                }
+            });
         }
     }
 


### PR DESCRIPTION
删除索引的时候容易出现timeout，主要是阻塞在等待target更新脚本返回。将更新target放在异步执行，同步只删除相关配置、segment文件。
下面是阻塞的堆栈示例：
```
"havenask[l57e02076.sqa.nu8][clusterApplierService#updateTask][T#1]" #23 daemon prio=5 os_prio=0 cpu=137.13ms elapsed=2838.27s tid=0x00007f573a582990 nid=0x260 in Object.wait()  [0x00007f56a5df5000]
   java.lang.Thread.State: TIMED_WAITING (on object monitor)
        at java.lang.Object.wait(java.base@15/Native Method)
        - waiting on <0x00000000f73e59c8> (a java.lang.ProcessImpl)
        at java.lang.Object.wait(java.base@15/Object.java:455)
        at java.util.concurrent.TimeUnit.timedWait(java.base@15/TimeUnit.java:408)
        at java.lang.ProcessImpl.waitFor(java.base@15/ProcessImpl.java:448)
        - locked <0x00000000f73e59c8> (a java.lang.ProcessImpl)
        at org.havenask.engine.NativeProcessControlService.lambda$runScript$5(NativeProcessControlService.java:389)
        at org.havenask.engine.NativeProcessControlService$$Lambda$2787/0x00000008011444d0.run(Unknown Source)
        at java.security.AccessController.executePrivileged(java.base@15/AccessController.java:753)
        at java.security.AccessController.doPrivileged(java.base@15/AccessController.java:312)
        at org.havenask.engine.NativeProcessControlService.runScript(NativeProcessControlService.java:384)
        at org.havenask.engine.NativeProcessControlService.updateDataNodeTarget(NativeProcessControlService.java:356)
        at org.havenask.engine.HavenaskEngineEnvironment.deleteShardDirectoryUnderLock(HavenaskEngineEnvironment.java:139)
        at org.havenask.env.NodeEnvironment.deleteShardDirectoryUnderLock(NodeEnvironment.java:564)
        at org.havenask.indices.IndicesService.deleteShardStore(IndicesService.java:959)
        at org.havenask.index.IndexService.onShardClose(IndexService.java:583)
        at org.havenask.index.IndexService.access$100(IndexService.java:132)
        at org.havenask.index.IndexService$StoreCloseListener.accept(IndexService.java:670)
        at org.havenask.index.IndexService$StoreCloseListener.accept(IndexService.java:657)
        at org.havenask.index.store.Store.closeInternal(Store.java:458)
        at org.havenask.index.store.Store.access$000(Store.java:152)
        at org.havenask.index.store.Store$1.closeInternal(Store.java:184)
        at org.havenask.common.util.concurrent.AbstractRefCounted.decRef(AbstractRefCounted.java:83)
        at org.havenask.index.store.Store.decRef(Store.java:431)
        at org.havenask.index.store.Store.close(Store.java:438)
        at org.havenask.index.IndexService.closeShard(IndexService.java:564)
        at org.havenask.index.IndexService.removeShard(IndexService.java:532)
        - locked <0x00000000ec6d3090> (a org.havenask.index.IndexService)
        at org.havenask.index.IndexService.close(IndexService.java:347)
        - locked <0x00000000ec6d3090> (a org.havenask.index.IndexService)
        at org.havenask.indices.IndicesService.removeIndex(IndicesService.java:823)
        at org.havenask.indices.cluster.IndicesClusterStateService.deleteIndices(IndicesClusterStateService.java:322)
        at org.havenask.indices.cluster.IndicesClusterStateService.applyClusterState(IndicesClusterStateService.java:256)
        - locked <0x00000000ec65ab60> (a org.havenask.indices.cluster.IndicesClusterStateService)
        at org.havenask.cluster.service.ClusterApplierService.callClusterStateAppliers(ClusterApplierService.java:530)
        at org.havenask.cluster.service.ClusterApplierService.callClusterStateAppliers(ClusterApplierService.java:520)
        at org.havenask.cluster.service.ClusterApplierService.applyChanges(ClusterApplierService.java:491)
        at org.havenask.cluster.service.ClusterApplierService.runTask(ClusterApplierService.java:438)
        at org.havenask.cluster.service.ClusterApplierService.access$000(ClusterApplierService.java:88)
        at org.havenask.cluster.service.ClusterApplierService$UpdateTask.run(ClusterApplierService.java:182)
        at org.havenask.common.util.concurrent.ThreadContext$ContextPreservingRunnable.run(ThreadContext.java:704)
        at org.havenask.common.util.concurrent.PrioritizedHavenaskThreadPoolExecutor$TieBreakingPrioritizedRunnable.runAndClean(PrioritizedHavenaskThreadPoolExecutor.java:273)
        at org.havenask.common.util.concurrent.PrioritizedHavenaskThreadPoolExecutor$TieBreakingPrioritizedRunnable.run(PrioritizedHavenaskThreadPoolExecutor.java:236)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@15/ThreadPoolExecutor.java:1130)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@15/ThreadPoolExecutor.java:630)
        at java.lang.Thread.run(java.base@15/Thread.java:832)
```