### PR TITLE
delete havenask索引流程优化，只在havenask索引进行delete相关操作

### DIFF
--- a/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/HavenaskEngineEnvironment.java
+++ b/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/HavenaskEngineEnvironment.java
@@ -27,6 +27,7 @@ import org.havenask.common.settings.Settings;
 import org.havenask.core.internal.io.IOUtils;
 import org.havenask.engine.index.config.generator.BizConfigGenerator;
 import org.havenask.engine.index.config.generator.TableConfigGenerator;
+import org.havenask.engine.index.engine.EngineSettings;
 import org.havenask.env.Environment;
 import org.havenask.env.ShardLock;
 import org.havenask.index.Index;
@@ -125,6 +126,9 @@ public class HavenaskEngineEnvironment implements CustomEnvironment {
 
     @Override
     public void deleteIndexDirectoryUnderLock(Index index, IndexSettings indexSettings) throws IOException {
+        if (EngineSettings.isHavenaskEngine(indexSettings.getSettings()) == false) {
+            return;
+        }
         BizConfigGenerator.removeBiz(index.getName(), configPath);
         TableConfigGenerator.removeTable(index.getName(), configPath);
         Path indexDir = runtimedataPath.resolve(index.getName());

--- a/elastic-fed/modules/havenask-engine/src/test/java/org/havenask/engine/HavenaskEngineEnvironmentTests.java
+++ b/elastic-fed/modules/havenask-engine/src/test/java/org/havenask/engine/HavenaskEngineEnvironmentTests.java
@@ -31,7 +31,6 @@ import org.havenask.env.Environment;
 import org.havenask.env.TestEnvironment;
 import org.havenask.index.Index;
 import org.havenask.index.IndexSettings;
-import org.havenask.index.engine.EngineConfig;
 import org.havenask.test.HavenaskTestCase;
 
 import static org.havenask.discovery.DiscoveryModule.SINGLE_NODE_DISCOVERY_TYPE;
@@ -73,7 +72,8 @@ public class HavenaskEngineEnvironmentTests extends HavenaskTestCase {
             .numberOfShards(1)
             .numberOfReplicas(0)
             .build();
-        havenaskEngineEnvironment.deleteIndexDirectoryUnderLock(new Index("indexFile", "indexFile"), new IndexSettings(build, Settings.EMPTY));
+        havenaskEngineEnvironment.deleteIndexDirectoryUnderLock(new Index("indexFile", "indexFile"),
+            new IndexSettings(build, Settings.EMPTY));
         TestCase.assertFalse(Files.exists(indexFile));
     }
 }

--- a/elastic-fed/modules/havenask-engine/src/test/java/org/havenask/engine/HavenaskEngineEnvironmentTests.java
+++ b/elastic-fed/modules/havenask-engine/src/test/java/org/havenask/engine/HavenaskEngineEnvironmentTests.java
@@ -72,8 +72,10 @@ public class HavenaskEngineEnvironmentTests extends HavenaskTestCase {
             .numberOfShards(1)
             .numberOfReplicas(0)
             .build();
-        havenaskEngineEnvironment.deleteIndexDirectoryUnderLock(new Index("indexFile", "indexFile"),
-            new IndexSettings(build, Settings.EMPTY));
+        havenaskEngineEnvironment.deleteIndexDirectoryUnderLock(
+            new Index("indexFile", "indexFile"),
+            new IndexSettings(build, Settings.EMPTY)
+        );
         TestCase.assertFalse(Files.exists(indexFile));
     }
 }


### PR DESCRIPTION
之前在HavenaskEngineEnvironment.deleteIndexDirectoryUnderLock会处理所有索引，现在改为只处理havenask索引