### PR TITLE
当searcher和qrs启动失败再次循环启动时，增加了sleep机制

### DIFF
--- a/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/NativeProcessControlService.java
+++ b/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/NativeProcessControlService.java
@@ -294,7 +294,14 @@ public class NativeProcessControlService extends AbstractLifecycleComponent {
             LOGGER.info("start searcher process...");
             while (false == checkProcessAlive(SEARCHER_ROLE)) {
                 // 启动searcher
-                runCommand(startSearcherCommand);
+                boolean runSearcherState = runCommand(startSearcherCommand);
+                if (!runSearcherState) {
+                    try {
+                        Thread.sleep(1000);
+                    } catch (InterruptedException e) {
+                        LOGGER.warn("start searcher process failed, and sleep error occurs", e);
+                    }
+                }
             }
         }
 
@@ -302,7 +309,14 @@ public class NativeProcessControlService extends AbstractLifecycleComponent {
             LOGGER.info("start qrs process...");
             while (false == checkProcessAlive(QRS_ROLE)) {
                 // 启动qrs
-                runCommand(startQrsCommand);
+                boolean runQrsState = runCommand(startQrsCommand);
+                if (!runQrsState) {
+                    try {
+                        Thread.sleep(1000);
+                    } catch (InterruptedException e) {
+                        LOGGER.warn("start qrs process failed, and sleep error occurs", e);
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
当searcher和qrs启动失败再次循环启动时，增加了1s的sleep。