### PR TITLE
增加参数FSLIB_LOCAL_ASYNC_CORO_READ=0，防止cpu启动就飙高

### DIFF
--- a/elastic-fed/modules/havenask-engine/config/havenask/command/general_search_starter.py
+++ b/elastic-fed/modules/havenask-engine/config/havenask/command/general_search_starter.py
@@ -314,6 +314,9 @@ examples:
             self.startCmdTemplate += " --env localBizService=true"
         self.startCmdTemplate += " --env asyncInterExecutorType=simple"
         self.startCmdTemplate += " --env asyncIntraExecutorType=simple"
+        self.startCmdTemplate += " --env FSLIB_LOCAL_ASYNC_CORO_READ=0"
+        self.startCmdTemplate += " --env SLEEP_CPU_FOR_TEST=1"
+
         self.alogConfigPath = os.path.join(self.binaryPath, "usr/local/etc/ha3/ha3_alog.conf")
         self.searchCfg = os.path.join(self.binaryPath, "usr/local/etc/ha3/search_server.cfg")
         self.qrsCfg = os.path.join(self.binaryPath, "usr/local/etc/ha3/qrs_server.cfg")


### PR DESCRIPTION
之前searcher、qrs一启动，就会有400%的cpu一直在run，加上FSLIB_LOCAL_ASYNC_CORO_READ=0参数后，修复该问题