### PR TITLE
searcher更新数据表时，更新zone的version值，以提供qrs更新

### DIFF
--- a/elastic-fed/modules/havenask-engine/config/havenask/command/general_search_updater.py
+++ b/elastic-fed/modules/havenask-engine/config/havenask/command/general_search_updater.py
@@ -253,14 +253,14 @@ examples:
                 if response["signature"] == requestSig:
                     serviceInfo = json.loads(response["serviceInfo"])
                     infos = serviceInfo["cm2"]["topo_info"].strip('|').split('|')
-                    version = int(splitInfo[3]) + random.randint(1,100000)
+                    random_version = random.randint(1,100000)
                     for info in infos:
                         splitInfo = info.split(':')
                         localConfig = {}
                         localConfig["biz_name"] = splitInfo[0]
                         localConfig["part_count"] = int(splitInfo[1])
                         localConfig["part_id"] = int(splitInfo[2])
-                        localConfig["version"] = version
+                        localConfig["version"] = int(splitInfo[3]) + random_version
                         localConfig["ip"] = self.ip
                         localConfig["tcp_port"] = arpcPort
                         if grpcPort != 0:

--- a/elastic-fed/modules/havenask-engine/config/havenask/command/general_search_updater.py
+++ b/elastic-fed/modules/havenask-engine/config/havenask/command/general_search_updater.py
@@ -11,6 +11,7 @@ import json
 import time
 import general_search_starter
 import re
+import random
 
 class GeneralSearchUpdateCmd(general_search_starter.GeneralSearchStartCmd):
     '''
@@ -252,13 +253,14 @@ examples:
                 if response["signature"] == requestSig:
                     serviceInfo = json.loads(response["serviceInfo"])
                     infos = serviceInfo["cm2"]["topo_info"].strip('|').split('|')
+                    version = int(splitInfo[3]) + random.randint(1,100000)
                     for info in infos:
                         splitInfo = info.split(':')
                         localConfig = {}
                         localConfig["biz_name"] = splitInfo[0]
                         localConfig["part_count"] = int(splitInfo[1])
                         localConfig["part_id"] = int(splitInfo[2])
-                        localConfig["version"] = int(splitInfo[3])
+                        localConfig["version"] = version
                         localConfig["ip"] = self.ip
                         localConfig["tcp_port"] = arpcPort
                         if grpcPort != 0:


### PR DESCRIPTION
修复新建索引无法查询的问题。
增加直写配置后，searcher不会更新cm2的version，导致qrs无法更新target。现在加上随机值，确保qrs正常更新。