### PR TITLE
修复delete文档的错误逻辑

### DIFF
--- a/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/index/engine/HavenaskEngine.java
+++ b/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/index/engine/HavenaskEngine.java
@@ -368,7 +368,7 @@ public class HavenaskEngine extends InternalEngine {
     public DeleteResult delete(Delete delete) throws IOException {
         Map<String, String> haDoc = new HashMap<>();
         haDoc.put(IdFieldMapper.NAME, delete.id());
-        if (false == realTimeEnable) {
+        if (realTimeEnable) {
             ProducerRecord<String, String> record = buildProducerRecord(
                 delete.id(),
                 delete.operationType(),


### PR DESCRIPTION
开启realTimeEnable使用的是kafka模式，默认是关闭，支持只写