### PR TITLE
添加启动havenask docker的集成测试用例框架

### DIFF
--- a/elastic-fed/qa/havenask-docker/build.gradle
+++ b/elastic-fed/qa/havenask-docker/build.gradle
@@ -1,0 +1,99 @@
+/* 
+*Copyright (c) 2021, Alibaba Group;
+*Licensed under the Apache License, Version 2.0 (the "License");
+*you may not use this file except in compliance with the License.
+*You may obtain a copy of the License at
+
+*   http://www.apache.org/licenses/LICENSE-2.0
+
+*Unless required by applicable law or agreed to in writing, software
+*distributed under the License is distributed on an "AS IS" BASIS,
+*WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*See the License for the specific language governing permissions and
+*limitations under the License.
+*
+* Modifications Copyright Havenask Contributors. See
+* GitHub history for details.
+*/
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.havenask.gradle.Architecture
+import org.havenask.gradle.VersionProperties
+import org.havenask.gradle.testfixtures.TestFixturesPlugin
+
+apply plugin: 'havenask.standalone-rest-test'
+apply plugin: 'havenask.test.fixtures'
+apply plugin: 'havenask.internal-distribution-download'
+
+testFixtures.useFixture()
+
+dependencies {
+  testImplementation project(':client:rest-high-level')
+  testImplementation project(':modules:havenask-engine')
+}
+
+havenask_distributions {
+  docker {
+    type = 'docker'
+    architecture = Architecture.current()
+    version = VersionProperties.getHavenask()
+    failIfUnavailable = false // This ensures we skip this testing if Docker is unavailable
+  }
+}
+
+preProcessFixture {
+  dependsOn havenask_distributions.docker
+  doLast {
+    // tests expect to have an empty repo
+    project.delete(
+      "${buildDir}/repo"
+    )
+    createAndSetWritable(
+      "${buildDir}/repo",
+      "${buildDir}/logs/1",
+      "${buildDir}/logs/2"
+    )
+  }
+}
+
+dockerCompose {
+  tcpPortsToIgnoreWhenWaiting = [9600, 9601]
+  useComposeFiles = ['docker-compose.yml']
+}
+
+def createAndSetWritable(Object... locations) {
+  locations.each { location ->
+    File file = file(location)
+    file.mkdirs()
+    file.setWritable(true, false)
+  }
+}
+
+tasks.register("integTest", Test) {
+  outputs.doNotCacheIf('Build cache is disabled for Docker tests') { true }
+  maxParallelForks = '1'
+  include '**/*IT.class'
+}
+
+tasks.named("check").configure { dependsOn "integTest" }
+
+sourceCompatibility = JavaVersion.VERSION_11
+targetCompatibility = JavaVersion.VERSION_11

--- a/elastic-fed/qa/havenask-docker/docker-compose.yml
+++ b/elastic-fed/qa/havenask-docker/docker-compose.yml
@@ -1,0 +1,38 @@
+# Only used for testing the docker images
+version: '3.7'
+services:
+  havenask-1:
+    image: havenask-fed:test
+    environment:
+       - node.name=havenask-1
+       - cluster.name=havenask-1
+       - bootstrap.memory_lock=true
+       - network.publish_host=127.0.0.1
+       - "HAVENASK_JAVA_OPTS=-Xms512m -Xmx512m"
+       - path.repo=/tmp/havenask-repo
+       - node.attr.testattr=test
+       - cluster.routing.allocation.disk.watermark.low=1b
+       - cluster.routing.allocation.disk.watermark.high=1b
+       - cluster.routing.allocation.disk.watermark.flood_stage=1b
+       - node.store.allow_mmap=false
+       - discovery.type=single-node
+       - havenask.engine.enabled=true
+    volumes:
+       - ./build/repo:/tmp/havenask-repo
+       - ./build/logs/1:/usr/share/havenask/logs
+    ports:
+      - "9200"
+      - "9300"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536
+        hard: 65536
+    healthcheck:
+      start_period: 15s
+      test: ["CMD", "curl", "-f", "http://localhost:9200"]
+      interval: 10s
+      timeout: 2s
+      retries: 5

--- a/elastic-fed/qa/havenask-docker/docker-test-entrypoint.sh
+++ b/elastic-fed/qa/havenask-docker/docker-test-entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+cd /usr/share/havenask/bin/
+./havenask-users useradd rest_user -p test-password -r superuser || true
+echo "testnode" > /tmp/password
+/usr/local/bin/docker-entrypoint.sh | tee > /usr/share/havenask/logs/console.log

--- a/elastic-fed/qa/havenask-docker/src/test/java/org/havenask/cluster/remote/test/AbstractHavenaskClusterTestCase.java
+++ b/elastic-fed/qa/havenask-docker/src/test/java/org/havenask/cluster/remote/test/AbstractHavenaskClusterTestCase.java
@@ -1,0 +1,129 @@
+/*
+*Copyright (c) 2021, Alibaba Group;
+*Licensed under the Apache License, Version 2.0 (the "License");
+*you may not use this file except in compliance with the License.
+*You may obtain a copy of the License at
+
+*   http://www.apache.org/licenses/LICENSE-2.0
+
+*Unless required by applicable law or agreed to in writing, software
+*distributed under the License is distributed on an "AS IS" BASIS,
+*WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*See the License for the specific language governing permissions and
+*limitations under the License.
+*/
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Modifications Copyright Havenask Contributors. See
+ * GitHub history for details.
+ */
+
+package org.havenask.cluster.remote.test;
+
+import org.apache.http.HttpHost;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.havenask.action.admin.cluster.health.ClusterHealthRequest;
+import org.havenask.client.RequestOptions;
+import org.havenask.client.RestClient;
+import org.havenask.client.RestHighLevelClient;
+import org.havenask.common.settings.Settings;
+import org.havenask.core.internal.io.IOUtils;
+import org.havenask.test.rest.HavenaskRestTestCase;
+
+import java.io.IOException;
+import java.util.Collections;
+
+public abstract class AbstractHavenaskClusterTestCase extends HavenaskRestTestCase {
+
+    @Override
+    protected boolean preserveClusterUponCompletion() {
+        return true;
+    }
+
+    private static RestHighLevelClient clusterClient;
+    private static boolean initialized = false;
+
+
+    @Override
+    protected String getTestRestCluster() {
+        return "localhost:" + getProperty("test.fixtures.havenask-1.tcp.9200");
+    }
+
+    @Before
+    public void initClientsAndConfigureClusters() throws Exception {
+        if (initialized) {
+            return;
+        }
+
+        clusterClient = buildClient("localhost:" + getProperty("test.fixtures.havenask-1.tcp.9200"));
+
+        clusterClient().cluster().health(new ClusterHealthRequest().waitForNodes("1").waitForYellowStatus(), RequestOptions.DEFAULT);
+
+        initialized = true;
+    }
+
+
+    @AfterClass
+    public static void destroyClients() throws IOException {
+        try {
+            IOUtils.close(clusterClient);
+        } finally {
+            clusterClient = null;
+        }
+    }
+
+    protected static RestHighLevelClient clusterClient() {
+        return clusterClient;
+    }
+
+    private static class HighLevelClient extends RestHighLevelClient {
+        private HighLevelClient(RestClient restClient) {
+            super(restClient, RestClient::close, Collections.emptyList());
+        }
+    }
+
+    private RestHighLevelClient buildClient(final String url) throws IOException {
+        int portSeparator = url.lastIndexOf(':');
+        HttpHost httpHost = new HttpHost(url.substring(0, portSeparator),
+            Integer.parseInt(url.substring(portSeparator + 1)), getProtocol());
+        return new HighLevelClient(buildClient(restAdminSettings(), new HttpHost[]{httpHost}));
+    }
+
+    @Override
+    protected Settings restClientSettings() {
+        return super.restClientSettings();
+    }
+
+    @Override
+    protected String getProtocol() {
+        return "http";
+    }
+
+    private String getProperty(String key) {
+        String value = System.getProperty(key);
+        if (value == null) {
+            throw new IllegalStateException("Could not find system properties from test.fixtures. " +
+                "This test expects to run with the havenask.test.fixtures Gradle plugin");
+        }
+        return value;
+    }
+}

--- a/elastic-fed/qa/havenask-docker/src/test/java/org/havenask/cluster/remote/test/BasicIT.java
+++ b/elastic-fed/qa/havenask-docker/src/test/java/org/havenask/cluster/remote/test/BasicIT.java
@@ -1,0 +1,73 @@
+/*
+ *Copyright (c) 2021, Alibaba Group;
+ *Licensed under the Apache License, Version 2.0 (the "License");
+ *you may not use this file except in compliance with the License.
+ *You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ *Unless required by applicable law or agreed to in writing, software
+ *distributed under the License is distributed on an "AS IS" BASIS,
+ *WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *See the License for the specific language governing permissions and
+ *limitations under the License.
+ */
+
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Modifications Copyright Havenask Contributors. See
+ * GitHub history for details.
+ */
+
+package org.havenask.cluster.remote.test;
+
+import org.havenask.action.admin.indices.delete.DeleteIndexRequest;
+import org.havenask.client.RequestOptions;
+import org.havenask.client.indices.CreateIndexRequest;
+import org.havenask.client.indices.GetIndexRequest;
+import org.havenask.client.indices.GetIndexResponse;
+import org.havenask.cluster.metadata.MappingMetadata;
+import org.havenask.common.collect.Map;
+import org.havenask.common.settings.Settings;
+import org.havenask.engine.index.engine.EngineSettings;
+
+import java.io.IOException;
+
+public class BasicIT extends AbstractHavenaskClusterTestCase {
+
+    public void testCRUD() throws IOException {
+        String index = "test1";
+        assertTrue(clusterClient().indices().create(
+            new CreateIndexRequest(index).settings(
+                Settings.builder().put(EngineSettings.ENGINE_TYPE_SETTING.getKey(), EngineSettings.ENGINE_HAVENASK)
+                    .build()),
+            RequestOptions.DEFAULT).isAcknowledged());
+
+        GetIndexResponse getIndexResponse = clusterClient().indices().get(new GetIndexRequest(index),
+            RequestOptions.DEFAULT);
+        assertEquals(getIndexResponse.getIndices().length, 1);
+        assertEquals(getIndexResponse.getSetting(index, EngineSettings.ENGINE_TYPE_SETTING.getKey()), EngineSettings.ENGINE_HAVENASK);
+        assertEquals(getIndexResponse.getSetting(index, "index.number_of_replicas"), "0");
+        assertEquals(getIndexResponse.getMappings().get(index), new MappingMetadata("_doc", Map.of("dynamic", "false")));
+
+        assertTrue(
+            clusterClient().indices().delete(new DeleteIndexRequest(index), RequestOptions.DEFAULT).isAcknowledged());
+    }
+}


### PR DESCRIPTION
在qa/havenask-docker模块增加fed的集成测试框架，支持拉起一个docker，启动fed进程。进行真实环境的的集成测试。