### PR TITLE
输入非法构造参数时，显示非法参数的具体值

### DIFF
--- a/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/index/engine/CheckpointCalc.java
+++ b/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/index/engine/CheckpointCalc.java
@@ -40,13 +40,13 @@ public class CheckpointCalc {
 
     CheckpointCalc(long milisPerSegment, long timeGapMargin, int segmentSize) {
         if (milisPerSegment <= 0) {
-            throw new IllegalArgumentException("milisPerSegment must be positive");
+            throw new IllegalArgumentException("milisPerSegment must be positive, illegal value: " + milisPerSegment);
         }
         if (timeGapMargin < 0) {
-            throw new IllegalArgumentException("timeGapMargin must be non-negative");
+            throw new IllegalArgumentException("timeGapMargin must be non-negative, illegal value: " + timeGapMargin);
         }
         if (segmentSize <= 0) {
-            throw new IllegalArgumentException("segmentSize must be positive");
+            throw new IllegalArgumentException("segmentSize must be positive, illegal value: " + segmentSize);
         }
         this.milisPerSegment = milisPerSegment;
         this.timeGapMargin = timeGapMargin;

--- a/elastic-fed/modules/havenask-engine/src/test/java/org/havenask/engine/index/engine/CheckpointCalcTests.java
+++ b/elastic-fed/modules/havenask-engine/src/test/java/org/havenask/engine/index/engine/CheckpointCalcTests.java
@@ -198,19 +198,19 @@ public class CheckpointCalcTests extends HavenaskTestCase {
             CheckpointCalc checkpointCalc = new CheckpointCalc(0, 0, 5);
             fail("should throw IllegalArgumentException");
         } catch (IllegalArgumentException e) {
-            assertEquals("milisPerSegment must be positive", e.getMessage());
+            assertEquals("milisPerSegment must be positive, illegal value: 0", e.getMessage());
         }
         try {
             CheckpointCalc checkpointCalc = new CheckpointCalc(100, -1, 5);
             fail("should throw IllegalArgumentException");
         } catch (IllegalArgumentException e) {
-            assertEquals("timeGapMargin must be non-negative", e.getMessage());
+            assertEquals("timeGapMargin must be non-negative, illegal value: -1", e.getMessage());
         }
         try {
             CheckpointCalc checkpointCalc = new CheckpointCalc(100, 0, 0);
             fail("should throw IllegalArgumentException");
         } catch (IllegalArgumentException e) {
-            assertEquals("segmentSize must be positive", e.getMessage());
+            assertEquals("segmentSize must be positive, illegal value: 0", e.getMessage());
         }
     }
 }


### PR DESCRIPTION
在原有错误说明的基础上增加了“illegal value: XXX”