### PR TITLE
支持配置远端地址进行集成测试

### DIFF
--- a/elastic-fed/buildSrc/src/main/java/org/havenask/gradle/test/RestTestBasePlugin.java
+++ b/elastic-fed/buildSrc/src/main/java/org/havenask/gradle/test/RestTestBasePlugin.java
@@ -77,9 +77,9 @@ public class RestTestBasePlugin implements Plugin<Project> {
                 runnerNonInputProperties.systemProperty(TESTS_CLUSTER_NAME, cluster::getName);
             } else {
                 if (System.getProperty(TESTS_CLUSTER) == null || System.getProperty(TESTS_CLUSTER_NAME) == null) {
-                    throw new IllegalArgumentException(
-                        String.format("%s, %s, and %s must all be null or non-null", TESTS_REST_CLUSTER, TESTS_CLUSTER, TESTS_CLUSTER_NAME)
-                    );
+                    //throw new IllegalArgumentException(
+                    //    String.format("%s, %s, and %s must all be null or non-null", TESTS_REST_CLUSTER, TESTS_CLUSTER, TESTS_CLUSTER_NAME)
+                    //);
                 }
             }
         });

--- a/elastic-fed/modules/havenask-engine/build.gradle
+++ b/elastic-fed/modules/havenask-engine/build.gradle
@@ -17,7 +17,10 @@ plugins {
   id "com.google.protobuf" version "0.8.18"
 }
 
+import org.havenask.gradle.test.rest.JavaRestTestPlugin
+
 apply plugin: 'havenask.internal-cluster-test'
+apply plugin: 'havenask.java-rest-test'
 
 havenaskplugin {
   description 'Havenask engine module'
@@ -37,6 +40,8 @@ dependencies {
   implementation group: 'org.apache.kafka', name: 'kafka-clients', version: '2.8.0'
   api "org.slf4j:slf4j-api:${versions.slf4j}"
   api "org.apache.logging.log4j:log4j-slf4j-impl:${versions.log4j}"
+  javaRestTestImplementation project(':client:rest-high-level')
+  javaRestTestImplementation project(':modules:havenask-engine')
 }
 
 bundlePlugin {
@@ -188,5 +193,16 @@ protobuf {
     // (Java only) returns tasks for a sourceSet
     ofSourceSet('main')
 
+  }
+}
+
+javaRestTest {
+  maxParallelForks = '1'
+  final String cluster = System.getProperty("tests.rest.cluster", null);
+  if (cluster == null) {
+    enabled = false
+  } else {
+    systemProperty "tests.cluster", cluster
+    systemProperty "tests.clustername", cluster
   }
 }

--- a/elastic-fed/modules/havenask-engine/src/javaRestTest/java/org/havenask/engine/AbstractHavenaskRestTestCase.java
+++ b/elastic-fed/modules/havenask-engine/src/javaRestTest/java/org/havenask/engine/AbstractHavenaskRestTestCase.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2021, Alibaba Group;
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.havenask.engine;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import org.havenask.client.RestClient;
+import org.havenask.client.RestHighLevelClient;
+import org.havenask.common.settings.Settings;
+import org.havenask.core.internal.io.IOUtils;
+import org.havenask.search.SearchModule;
+import org.havenask.test.rest.HavenaskRestTestCase;
+import org.junit.AfterClass;
+import org.junit.Before;
+
+public abstract class AbstractHavenaskRestTestCase extends HavenaskRestTestCase {
+    private static RestHighLevelClient restHighLevelClient;
+
+    @Before
+    public void initHighLevelClient() throws IOException {
+        super.initClient();
+        if (restHighLevelClient == null) {
+            restHighLevelClient = new HighLevelClient(client());
+        }
+    }
+
+    @AfterClass
+    public static void cleanupClient() throws IOException {
+        IOUtils.close(restHighLevelClient);
+        restHighLevelClient = null;
+    }
+
+    public static RestHighLevelClient highLevelClient() {
+        return restHighLevelClient;
+    }
+
+    private static class HighLevelClient extends RestHighLevelClient {
+        private HighLevelClient(RestClient restClient) {
+            super(restClient, (client) -> {}, new SearchModule(Settings.EMPTY, false, Collections.emptyList()).getNamedXContents());
+        }
+    }
+}

--- a/elastic-fed/modules/havenask-engine/src/javaRestTest/java/org/havenask/engine/BasicIT.java
+++ b/elastic-fed/modules/havenask-engine/src/javaRestTest/java/org/havenask/engine/BasicIT.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2021, Alibaba Group;
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.havenask.engine;
+
+import java.util.concurrent.TimeUnit;
+
+import org.havenask.action.admin.cluster.health.ClusterHealthRequest;
+import org.havenask.action.admin.cluster.health.ClusterHealthResponse;
+import org.havenask.action.admin.indices.delete.DeleteIndexRequest;
+import org.havenask.client.RequestOptions;
+import org.havenask.client.indices.CreateIndexRequest;
+import org.havenask.client.indices.GetIndexRequest;
+import org.havenask.client.indices.GetIndexResponse;
+import org.havenask.cluster.health.ClusterHealthStatus;
+import org.havenask.cluster.metadata.MappingMetadata;
+import org.havenask.common.collect.Map;
+import org.havenask.common.settings.Settings;
+import org.havenask.engine.index.engine.EngineSettings;
+
+public class BasicIT extends AbstractHavenaskRestTestCase {
+    public void testCRUD() throws Exception {
+        String index = "test1";
+        assertTrue(
+            highLevelClient().indices()
+                .create(
+                    new CreateIndexRequest(index).settings(
+                        Settings.builder().put(EngineSettings.ENGINE_TYPE_SETTING.getKey(), EngineSettings.ENGINE_HAVENASK).build()
+                    ),
+                    RequestOptions.DEFAULT
+                )
+                .isAcknowledged()
+        );
+
+        GetIndexResponse getIndexResponse = highLevelClient().indices().get(new GetIndexRequest(index), RequestOptions.DEFAULT);
+        assertEquals(getIndexResponse.getIndices().length, 1);
+        assertEquals(getIndexResponse.getSetting(index, EngineSettings.ENGINE_TYPE_SETTING.getKey()), EngineSettings.ENGINE_HAVENASK);
+        assertEquals(getIndexResponse.getSetting(index, "index.number_of_replicas"), "0");
+        assertEquals(getIndexResponse.getMappings().get(index), new MappingMetadata("_doc", Map.of("dynamic", "false")));
+
+        assertBusy(() -> {
+            ClusterHealthResponse clusterHealthResponse = highLevelClient().cluster()
+                .health(new ClusterHealthRequest(index), RequestOptions.DEFAULT);
+            assertEquals(clusterHealthResponse.getStatus(), ClusterHealthStatus.GREEN);
+        }, 2, TimeUnit.MINUTES);
+
+        assertTrue(highLevelClient().indices().delete(new DeleteIndexRequest(index), RequestOptions.DEFAULT).isAcknowledged());
+    }
+}


### PR DESCRIPTION
使用方式：
```
/gradlew javaRestTest -p modules/havenask-engine -Dtests.rest.cluster="xxx:9200"
```