### PR TITLE
支持在searcher重启前，先failed 节点的havenask engine shard，进入recovery环节

### DIFF
--- a/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/NativeProcessControlService.java
+++ b/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/NativeProcessControlService.java
@@ -522,7 +522,7 @@ public class NativeProcessControlService extends AbstractLifecycleComponent {
 
     /**
      * 记录启动的engine
-     * @param engine
+     * @param engine 启动的engine
      */
     public void addHavenaskEngine(HavenaskEngine engine) {
         LOGGER.debug("add havenask engine, shardId: [{}]", engine.config().getShardId());
@@ -531,7 +531,7 @@ public class NativeProcessControlService extends AbstractLifecycleComponent {
 
     /**
      * remove关闭的engine
-     * @param engine
+     * @param engine 关闭的engine
      */
     public void removeHavenaskEngine(HavenaskEngine engine) {
         LOGGER.debug("remove havenask engine, shardId: [{}]", engine.config().getShardId());

--- a/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/NativeProcessControlService.java
+++ b/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/NativeProcessControlService.java
@@ -277,8 +277,14 @@ public class NativeProcessControlService extends AbstractLifecycleComponent {
             if (isDataNode) {
                 if (false == checkProcessAlive(SEARCHER_ROLE)) {
                     havenaskEngines.forEach((havenaskEngine) -> {
-                        LOGGER.warn("havenask searcher process is not alive, failed engine, shardId: {}", havenaskEngine.config().getShardId());
-                        EngineException e = new EngineException(havenaskEngine.config().getShardId(), "havenask searcher process is not alive");
+                        LOGGER.warn(
+                            "havenask searcher process is not alive, failed engine, shardId: {}",
+                            havenaskEngine.config().getShardId()
+                        );
+                        EngineException e = new EngineException(
+                            havenaskEngine.config().getShardId(),
+                            "havenask searcher process is not alive"
+                        );
                         havenaskEngine.failEngine("havenask searcher process is not alive", e);
                     });
                     LOGGER.info("start searcher process...");

--- a/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/NativeProcessControlService.java
+++ b/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/NativeProcessControlService.java
@@ -277,6 +277,7 @@ public class NativeProcessControlService extends AbstractLifecycleComponent {
             if (isDataNode) {
                 if (false == checkProcessAlive(SEARCHER_ROLE)) {
                     havenaskEngines.forEach((havenaskEngine) -> {
+                        LOGGER.warn("havenask searcher process is not alive, failed engine, shardId: {}", havenaskEngine.config().getShardId());
                         EngineException e = new EngineException(havenaskEngine.config().getShardId(), "havenask searcher process is not alive");
                         havenaskEngine.failEngine("havenask searcher process is not alive", e);
                     });
@@ -518,6 +519,7 @@ public class NativeProcessControlService extends AbstractLifecycleComponent {
      * @param engine
      */
     public void addHavenaskEngine(HavenaskEngine engine) {
+        LOGGER.debug("add havenask engine, shardId: [{}]", engine.config().getShardId());
         havenaskEngines.add(engine);
     }
 
@@ -526,6 +528,7 @@ public class NativeProcessControlService extends AbstractLifecycleComponent {
      * @param engine
      */
     public void removeHavenaskEngine(HavenaskEngine engine) {
+        LOGGER.debug("remove havenask engine, shardId: [{}]", engine.config().getShardId());
         havenaskEngines.remove(engine);
     }
 }

--- a/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/index/engine/HavenaskEngine.java
+++ b/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/index/engine/HavenaskEngine.java
@@ -133,6 +133,8 @@ public class HavenaskEngine extends InternalEngine {
             failEngine("active havenask table failed", e);
             throw new EngineException(shardId, "active havenask table failed", e);
         }
+
+        nativeProcessControlService.addHavenaskEngine(this);
     }
 
     static KafkaProducer<String, String> initKafkaProducer(Settings settings) {
@@ -155,6 +157,8 @@ public class HavenaskEngine extends InternalEngine {
         if (realTimeEnable && producer != null) {
             producer.close();
         }
+
+        nativeProcessControlService.removeHavenaskEngine(this);
     }
 
     /**


### PR DESCRIPTION
fed重启能直接进入recovery环节。但是searcher重启，fed如果在engine层感知不到的话，会导致无法恢复数据，从而可能导致数据丢失。
在检测到searcher离线，进行重启的流程前，先failed节点上全部的havenask engine shard，这样在searcher后，能进入recovery shard流程