### PR TITLE
重载方法，方便自适应选择集成测试后是否保留索引

### DIFF
--- a/elastic-fed/modules/havenask-engine/src/javaRestTest/java/org/havenask/engine/AbstractHavenaskRestTestCase.java
+++ b/elastic-fed/modules/havenask-engine/src/javaRestTest/java/org/havenask/engine/AbstractHavenaskRestTestCase.java
@@ -43,6 +43,10 @@ public abstract class AbstractHavenaskRestTestCase extends HavenaskRestTestCase 
         restHighLevelClient = null;
     }
 
+    protected boolean preserveClusterUponCompletion() {
+        return true;
+    }
+
     public static RestHighLevelClient highLevelClient() {
         return restHighLevelClient;
     }


### PR DESCRIPTION
preserveClusterUponCompletion默认返回false，会在测试后删除所有索引，现在先改成返回true保留索引，方便调试。