### PR TITLE
写入失败后会进行重试，防止长时间不写入导致arpc连接关闭

### DIFF
--- a/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/rpc/arpc/SearcherArpcClient.java
+++ b/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/rpc/arpc/SearcherArpcClient.java
@@ -76,7 +76,7 @@ public class SearcherArpcClient implements SearcherClient, Closeable {
             if (writeResponse == null) {
                 resetChannel();
                 writeResponse = blockingStub.writeTable(controller, writeRequest);
-                if (writeResponse == null){
+                if (writeResponse == null) {
                     return new WriteResponse(ErrorCode.TBS_ERROR_UNKOWN, "write response is null, channel closed");
                 }
             }

--- a/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/rpc/arpc/SearcherArpcClient.java
+++ b/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/rpc/arpc/SearcherArpcClient.java
@@ -71,9 +71,14 @@ public class SearcherArpcClient implements SearcherClient, Closeable {
                 init();
             }
             suez.service.proto.WriteResponse writeResponse = blockingStub.writeTable(controller, writeRequest);
+
+            // double check for write, for the case that connection is unexpectedly closed
             if (writeResponse == null) {
                 resetChannel();
-                return new WriteResponse(ErrorCode.TBS_ERROR_UNKOWN, "write response is null, channel closed");
+                writeResponse = blockingStub.writeTable(controller, writeRequest);
+                if (writeResponse == null){
+                    return new WriteResponse(ErrorCode.TBS_ERROR_UNKOWN, "write response is null, channel closed");
+                }
             }
 
             if (writeResponse.getErrorInfo() == null || writeResponse.getErrorInfo().getErrorCode() == ErrorCode.TBS_ERROR_NONE) {

--- a/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/rpc/arpc/SearcherArpcClient.java
+++ b/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/rpc/arpc/SearcherArpcClient.java
@@ -75,9 +75,11 @@ public class SearcherArpcClient implements SearcherClient, Closeable {
             // double check for write, for the case that connection is unexpectedly closed
             if (writeResponse == null) {
                 resetChannel();
+                logger.info("write response is null, channel reset, retry...");
                 writeResponse = blockingStub.writeTable(controller, writeRequest);
                 if (writeResponse == null) {
-                    return new WriteResponse(ErrorCode.TBS_ERROR_UNKOWN, "write response is null, channel closed");
+                    resetChannel();
+                    return new WriteResponse(ErrorCode.TBS_ERROR_UNKOWN, "write response is null, channel reset");
                 }
             }
 


### PR DESCRIPTION
之前arpc如果长时间不写索引时连接会关闭，现在连接失败后会进行一次channel reset并重试