### PR TITLE
增加写入的退避重试，解决连接断开和havenask写入队列打满的问题

### DIFF
--- a/elastic-fed/modules/havenask-engine/src/test/java/org/havenask/engine/index/engine/HavenaskEngineTests.java
+++ b/elastic-fed/modules/havenask-engine/src/test/java/org/havenask/engine/index/engine/HavenaskEngineTests.java
@@ -15,19 +15,30 @@
 package org.havenask.engine.index.engine;
 
 import java.io.IOException;
+import java.util.Iterator;
 import java.util.Map;
 
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakFilters;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.havenask.action.bulk.BackoffPolicy;
 import org.havenask.common.settings.Settings;
+import org.havenask.common.unit.TimeValue;
+import org.havenask.engine.rpc.SearcherClient;
+import org.havenask.engine.rpc.WriteRequest;
+import org.havenask.engine.rpc.WriteResponse;
 import org.havenask.index.engine.Engine.Operation;
 import org.havenask.index.engine.EngineTestCase;
 import org.havenask.index.mapper.ParsedDocument;
+import suez.service.proto.ErrorCode;
 
+import static org.havenask.engine.index.engine.HavenaskEngine.DEFAULT_TIMEOUT;
+import static org.havenask.engine.index.engine.HavenaskEngine.MAX_RETRY;
 import static org.havenask.engine.index.engine.HavenaskEngine.buildProducerRecord;
 import static org.havenask.engine.index.engine.HavenaskEngine.initKafkaProducer;
 import static org.havenask.engine.index.engine.HavenaskEngine.toHaIndex;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @ThreadLeakFilters(filters = { KafkaThreadLeakFilter.class })
 public class HavenaskEngineTests extends EngineTestCase {
@@ -105,5 +116,60 @@ public class HavenaskEngineTests extends EngineTestCase {
         Settings settings = Settings.builder().put(EngineSettings.HAVENASK_REALTIME_BOOTSTRAP_SERVERS.getKey(), "127.0.0.1:9092").build();
         KafkaProducer<String, String> producer = initKafkaProducer(settings);
         assertNotNull(producer);
+    }
+
+    // test retryWrite
+    public void testRetryWriteTimeout() {
+        SearcherClient searcherClient = mock(SearcherClient.class);
+        WriteRequest writeRequest = mock(WriteRequest.class);
+        WriteResponse writeResponse = mock(WriteResponse.class);
+        when(searcherClient.write(writeRequest)).thenReturn(writeResponse);
+        when(writeResponse.getErrorCode()).thenReturn(ErrorCode.TBS_ERROR_UNKOWN);
+        when(writeResponse.getErrorMessage()).thenReturn("write response is null");
+        long start = System.currentTimeMillis();
+        WriteResponse response = HavenaskEngine.retryWrite(searcherClient, writeRequest);
+        long cost = System.currentTimeMillis() - start;
+        Iterator<TimeValue> backoff = BackoffPolicy.exponentialBackoff(DEFAULT_TIMEOUT, MAX_RETRY).iterator();
+        long backoffTime = 0;
+        while (backoff.hasNext()) {
+            backoffTime += backoff.next().millis();
+        }
+
+        assertTrue(cost > backoffTime);
+        assertEquals(response, writeResponse);
+    }
+
+    public void testRetryWriteQueueFull() {
+        SearcherClient searcherClient = mock(SearcherClient.class);
+        WriteRequest writeRequest = mock(WriteRequest.class);
+        WriteResponse writeResponse = mock(WriteResponse.class);
+        when(searcherClient.write(writeRequest)).thenReturn(writeResponse);
+        when(writeResponse.getErrorCode()).thenReturn(ErrorCode.TBS_ERROR_OTHERS);
+        when(writeResponse.getErrorMessage()).thenReturn("doc queue is full");
+        long start = System.currentTimeMillis();
+        WriteResponse response = HavenaskEngine.retryWrite(searcherClient, writeRequest);
+        long cost = System.currentTimeMillis() - start;
+        Iterator<TimeValue> backoff = BackoffPolicy.exponentialBackoff(DEFAULT_TIMEOUT, MAX_RETRY).iterator();
+        long backoffTime = 0;
+        while (backoff.hasNext()) {
+            backoffTime += backoff.next().millis();
+        }
+
+        assertTrue(cost > backoffTime);
+        assertEquals(response, writeResponse);
+    }
+
+    public void testWriteNoRetry() {
+        SearcherClient searcherClient = mock(SearcherClient.class);
+        WriteRequest writeRequest = mock(WriteRequest.class);
+        WriteResponse writeResponse = mock(WriteResponse.class);
+        when(searcherClient.write(writeRequest)).thenReturn(writeResponse);
+        when(writeResponse.getErrorCode()).thenReturn(ErrorCode.TBS_ERROR_NONE);
+        when(writeResponse.getErrorMessage()).thenReturn(null);
+        long start = System.currentTimeMillis();
+        WriteResponse response = HavenaskEngine.retryWrite(searcherClient, writeRequest);
+        long cost = System.currentTimeMillis() - start;
+        assertTrue(cost < DEFAULT_TIMEOUT.millis());
+        assertEquals(response, writeResponse);
     }
 }

--- a/elastic-fed/modules/havenask-engine/src/test/java/org/havenask/engine/index/engine/HavenaskEngineTests.java
+++ b/elastic-fed/modules/havenask-engine/src/test/java/org/havenask/engine/index/engine/HavenaskEngineTests.java
@@ -30,6 +30,7 @@ import org.havenask.engine.rpc.WriteResponse;
 import org.havenask.index.engine.Engine.Operation;
 import org.havenask.index.engine.EngineTestCase;
 import org.havenask.index.mapper.ParsedDocument;
+import org.havenask.index.shard.ShardId;
 import suez.service.proto.ErrorCode;
 
 import static org.havenask.engine.index.engine.HavenaskEngine.DEFAULT_TIMEOUT;
@@ -127,7 +128,7 @@ public class HavenaskEngineTests extends EngineTestCase {
         when(writeResponse.getErrorCode()).thenReturn(ErrorCode.TBS_ERROR_UNKOWN);
         when(writeResponse.getErrorMessage()).thenReturn("write response is null");
         long start = System.currentTimeMillis();
-        WriteResponse response = HavenaskEngine.retryWrite(searcherClient, writeRequest);
+        WriteResponse response = HavenaskEngine.retryWrite(mock(ShardId.class), searcherClient, writeRequest);
         long cost = System.currentTimeMillis() - start;
         Iterator<TimeValue> backoff = BackoffPolicy.exponentialBackoff(DEFAULT_TIMEOUT, MAX_RETRY).iterator();
         long backoffTime = 0;
@@ -147,7 +148,7 @@ public class HavenaskEngineTests extends EngineTestCase {
         when(writeResponse.getErrorCode()).thenReturn(ErrorCode.TBS_ERROR_OTHERS);
         when(writeResponse.getErrorMessage()).thenReturn("doc queue is full");
         long start = System.currentTimeMillis();
-        WriteResponse response = HavenaskEngine.retryWrite(searcherClient, writeRequest);
+        WriteResponse response = HavenaskEngine.retryWrite(mock(ShardId.class), searcherClient, writeRequest);
         long cost = System.currentTimeMillis() - start;
         Iterator<TimeValue> backoff = BackoffPolicy.exponentialBackoff(DEFAULT_TIMEOUT, MAX_RETRY).iterator();
         long backoffTime = 0;
@@ -167,7 +168,7 @@ public class HavenaskEngineTests extends EngineTestCase {
         when(writeResponse.getErrorCode()).thenReturn(ErrorCode.TBS_ERROR_NONE);
         when(writeResponse.getErrorMessage()).thenReturn(null);
         long start = System.currentTimeMillis();
-        WriteResponse response = HavenaskEngine.retryWrite(searcherClient, writeRequest);
+        WriteResponse response = HavenaskEngine.retryWrite(mock(ShardId.class), searcherClient, writeRequest);
         long cost = System.currentTimeMillis() - start;
         assertTrue(cost < DEFAULT_TIMEOUT.millis());
         assertEquals(response, writeResponse);


### PR DESCRIPTION
解决：https://github.com/alibaba/havenask-federation/issues/125 和 https://github.com/alibaba/havenask-federation/issues/156
同时在压测时，也经常出现队列打满，所以增加了退避重试功能