### PR TITLE
统一按JSON格式将_source写入havenask

### DIFF
--- a/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/index/engine/HavenaskEngine.java
+++ b/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/index/engine/HavenaskEngine.java
@@ -45,8 +45,11 @@ import org.apache.lucene.util.BytesRef;
 import org.havenask.HavenaskException;
 import org.havenask.action.bulk.BackoffPolicy;
 import org.havenask.common.Nullable;
+import org.havenask.common.bytes.BytesArray;
+import org.havenask.common.bytes.BytesReference;
 import org.havenask.common.settings.Settings;
 import org.havenask.common.unit.TimeValue;
+import org.havenask.common.xcontent.XContentHelper;
 import org.havenask.engine.HavenaskEngineEnvironment;
 import org.havenask.engine.NativeProcessControlService;
 import org.havenask.engine.index.config.generator.RuntimeSegmentGenerator;
@@ -288,7 +291,8 @@ public class HavenaskEngine extends InternalEngine {
             if (field.name().equals(IdFieldMapper.NAME)) {
                 haDoc.put(field.name(), Uid.decodeId(binaryVal.bytes));
             } else if (field.name().equals(SourceFieldMapper.NAME)) {
-                String src = binaryVal.utf8ToString();
+                BytesReference bytes = new BytesArray(binaryVal);
+                String src = XContentHelper.convertToJson(bytes, false, parsedDocument.getXContentType());
                 haDoc.put(field.name(), src);
             } else if (field instanceof VectorField) {
                 VectorField vectorField = (VectorField) field;


### PR DESCRIPTION
由于havenask的写入协议是文本协议，直接将二进制数据装入String会出现格式混乱甚至格式错误，现在统一将内容写入_source前转为JSON格式。