### PR TITLE
修复了isWarmedUp引起debug时的崩溃bug

### DIFF
--- a/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/index/engine/HavenaskEngine.java
+++ b/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/index/engine/HavenaskEngine.java
@@ -396,6 +396,12 @@ public class HavenaskEngine extends InternalEngine {
     }
 
     @Override
+    protected boolean assertSearcherIsWarmedUp(String source, SearcherScope scope) {
+        // for havenask we don't need to care about "externalReaderManager.isWarmedup"
+        return true;
+    }
+
+    @Override
     protected IndexResult indexIntoLucene(Index index, IndexingStrategy plan) throws IOException {
         index.parsedDoc().updateSeqID(index.seqNo(), index.primaryTerm());
         index.parsedDoc().version().setLongValue(plan.versionForIndexing);

--- a/elastic-fed/server/src/main/java/org/havenask/index/engine/InternalEngine.java
+++ b/elastic-fed/server/src/main/java/org/havenask/index/engine/InternalEngine.java
@@ -423,7 +423,7 @@ public class InternalEngine extends Engine {
     }
 
     @Override
-    final boolean assertSearcherIsWarmedUp(String source, SearcherScope scope) {
+    protected boolean assertSearcherIsWarmedUp(String source, SearcherScope scope) {
         if (scope == SearcherScope.EXTERNAL) {
             switch (source) {
                 // we can access segment_stats while a shard is still in the recovering state.


### PR DESCRIPTION
在dev镜像中以debug模式启动时会产生assert error，原因是isWarmedUp未置true，而此变量对于havenask引擎无影响，故暂时屏蔽。