### PR TITLE
暂时屏蔽向量索引的字段类型，等使用havenask最新版本再放开

### DIFF
--- a/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/HavenaskEnginePlugin.java
+++ b/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/HavenaskEnginePlugin.java
@@ -44,7 +44,6 @@ import org.havenask.common.xcontent.NamedXContentRegistry;
 import org.havenask.engine.index.HavenaskIndexEventListener;
 import org.havenask.engine.index.engine.EngineSettings;
 import org.havenask.engine.index.engine.HavenaskEngine;
-import org.havenask.engine.index.mapper.DenseVectorFieldMapper;
 import org.havenask.engine.rpc.HavenaskClient;
 import org.havenask.engine.rpc.QrsClient;
 import org.havenask.engine.rpc.SearcherClient;
@@ -308,6 +307,8 @@ public class HavenaskEnginePlugin extends Plugin
 
     @Override
     public Map<String, Mapper.TypeParser> getMappers() {
-        return Collections.singletonMap(DenseVectorFieldMapper.CONTENT_TYPE, new DenseVectorFieldMapper.TypeParser());
+        // TODO 暂时屏蔽向量索引字段,等使用havenask新版本再开放
+        // return Collections.singletonMap(DenseVectorFieldMapper.CONTENT_TYPE, new DenseVectorFieldMapper.TypeParser());
+        return Collections.emptyMap();
     }
 }

--- a/elastic-fed/modules/havenask-engine/src/test/java/org/havenask/engine/index/config/generator/BizConfigGeneratorTests.java
+++ b/elastic-fed/modules/havenask-engine/src/test/java/org/havenask/engine/index/config/generator/BizConfigGeneratorTests.java
@@ -326,6 +326,7 @@ public class BizConfigGeneratorTests extends MapperServiceTestCase {
         assertEquals(expect, zoneBizNew);
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/alibaba/havenask-federation/issues/202")
     public void testDupFieldProcessor() throws IOException {
         String indexName = randomAlphaOfLength(5);
         MapperService mapperService = createMapperService(mapping(b -> {

--- a/elastic-fed/modules/havenask-engine/src/test/java/org/havenask/engine/index/config/generator/SchemaGeneratorTests.java
+++ b/elastic-fed/modules/havenask-engine/src/test/java/org/havenask/engine/index/config/generator/SchemaGeneratorTests.java
@@ -431,6 +431,7 @@ public class SchemaGeneratorTests extends MapperServiceTestCase {
     }
 
     // test index vector
+    @AwaitsFix(bugUrl = "https://github.com/alibaba/havenask-federation/issues/202")
     public void testIndexVector() throws IOException {
         MapperService mapperService = createMapperService(mapping(b -> {
             {
@@ -534,6 +535,7 @@ public class SchemaGeneratorTests extends MapperServiceTestCase {
     }
 
     // test index vector with all parameters
+    @AwaitsFix(bugUrl = "https://github.com/alibaba/havenask-federation/issues/202")
     public void testIndexVectorWithAllParameters() throws IOException {
         MapperService mapperService = createMapperService(mapping(b -> {
             {

--- a/elastic-fed/modules/havenask-engine/src/test/java/org/havenask/engine/index/config/generator/TableConfigGeneratorTests.java
+++ b/elastic-fed/modules/havenask-engine/src/test/java/org/havenask/engine/index/config/generator/TableConfigGeneratorTests.java
@@ -248,6 +248,7 @@ public class TableConfigGeneratorTests extends MapperServiceTestCase {
         assertFalse(Files.exists(dataTablesPath));
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/alibaba/havenask-federation/issues/202")
     public void testDupFieldProcessor() throws IOException {
         String indexName = randomAlphaOfLength(5);
         MapperService mapperService = createMapperService(mapping(b -> {

--- a/elastic-fed/modules/havenask-engine/src/test/java/org/havenask/engine/index/mapper/DenseVectorFieldMapperTests.java
+++ b/elastic-fed/modules/havenask-engine/src/test/java/org/havenask/engine/index/mapper/DenseVectorFieldMapperTests.java
@@ -19,6 +19,7 @@ import java.util.Arrays;
 import java.util.Collection;
 
 import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.util.LuceneTestCase.AwaitsFix;
 import org.havenask.common.settings.Settings;
 import org.havenask.common.xcontent.XContentBuilder;
 import org.havenask.engine.HavenaskEnginePlugin;
@@ -35,6 +36,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 
+@AwaitsFix(bugUrl = "https://github.com/alibaba/havenask-federation/issues/202")
 public class DenseVectorFieldMapperTests extends MapperTestCase {
 
     @Override


### PR DESCRIPTION
havenask开启直写参数后，schema有向量索引会加载失败，具体见：https://github.com/alibaba/havenask/issues/118。
所以先暂时屏蔽，等havenask解决后再开启