### PR TITLE
searcher重启后会执行_cluster/reroute?retry_failed=true

### DIFF
--- a/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/HavenaskEnginePlugin.java
+++ b/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/HavenaskEnginePlugin.java
@@ -200,6 +200,7 @@ public class HavenaskEnginePlugin extends Plugin
         Supplier<RepositoriesService> repositoriesServiceSupplier
     ) {
         NativeProcessControlService nativeProcessControlService = new NativeProcessControlService(
+            client,
             clusterService,
             threadPool,
             environment,

--- a/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/NativeProcessControlService.java
+++ b/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/NativeProcessControlService.java
@@ -32,7 +32,6 @@ import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.havenask.HavenaskException;
 import org.havenask.client.Client;
 import org.havenask.client.Requests;
-import org.havenask.cluster.health.ClusterHealthStatus;
 import org.havenask.cluster.node.DiscoveryNode;
 import org.havenask.cluster.service.ClusterService;
 import org.havenask.common.component.AbstractLifecycleComponent;
@@ -299,12 +298,7 @@ public class NativeProcessControlService extends AbstractLifecycleComponent {
                     LOGGER.info("start searcher process...");
                     // 启动searcher
                     boolean isRestart = runCommand(startSearcherCommand, commandTimeout);
-                    if (isRestart
-                        && client.admin()
-                            .cluster()
-                            .health(Requests.clusterHealthRequest())
-                            .actionGet()
-                            .getStatus() == ClusterHealthStatus.RED) {
+                    if (isRestart) {
                         LOGGER.info("reroute cluster, set retryFailed to true");
                         client.admin().cluster().reroute(Requests.clusterRerouteRequest().setRetryFailed(true)).actionGet();
                     }

--- a/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/NativeProcessControlService.java
+++ b/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/NativeProcessControlService.java
@@ -30,9 +30,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.havenask.HavenaskException;
-import org.havenask.action.admin.cluster.health.ClusterHealthRequest;
-import org.havenask.action.admin.cluster.reroute.ClusterRerouteRequest;
 import org.havenask.client.Client;
+import org.havenask.client.Requests;
 import org.havenask.cluster.health.ClusterHealthStatus;
 import org.havenask.cluster.node.DiscoveryNode;
 import org.havenask.cluster.service.ClusterService;
@@ -136,7 +135,6 @@ public class NativeProcessControlService extends AbstractLifecycleComponent {
     private ProcessControlTask processControlTask;
     private boolean running;
     private final Set<HavenaskEngine> havenaskEngines = new HashSet<>();
-
     private Client client;
 
     public NativeProcessControlService(
@@ -342,9 +340,9 @@ public class NativeProcessControlService extends AbstractLifecycleComponent {
                 }
             }
 
-            if (client.admin().cluster().health(new ClusterHealthRequest()).actionGet().getStatus() == ClusterHealthStatus.RED) {
+            if (client.admin().cluster().health(Requests.clusterHealthRequest()).actionGet().getStatus() == ClusterHealthStatus.RED) {
                 LOGGER.info("reroute cluster, set retryFailed to true");
-                client.admin().cluster().reroute(new ClusterRerouteRequest().setRetryFailed(true)).actionGet();
+                client.admin().cluster().reroute(Requests.clusterRerouteRequest().setRetryFailed(true)).actionGet();
             }
         }
 

--- a/elastic-fed/modules/havenask-engine/src/test/java/org/havenask/engine/MockNativeProcessControlService.java
+++ b/elastic-fed/modules/havenask-engine/src/test/java/org/havenask/engine/MockNativeProcessControlService.java
@@ -14,6 +14,7 @@
 
 package org.havenask.engine;
 
+import org.havenask.client.Client;
 import org.havenask.cluster.service.ClusterService;
 import org.havenask.env.Environment;
 import org.havenask.env.NodeEnvironment;
@@ -21,13 +22,14 @@ import org.havenask.threadpool.ThreadPool;
 
 public class MockNativeProcessControlService extends NativeProcessControlService {
     public MockNativeProcessControlService(
+        Client client,
         ClusterService clusterService,
         ThreadPool threadPool,
         Environment environment,
         NodeEnvironment nodeEnvironment,
         HavenaskEngineEnvironment havenaskEngineEnvironment
     ) {
-        super(clusterService, threadPool, environment, nodeEnvironment, havenaskEngineEnvironment);
+        super(client, clusterService, threadPool, environment, nodeEnvironment, havenaskEngineEnvironment);
         String startScript = MockNativeProcessControlService.class.getResource("/fake_sap.sh").getPath();
         String stopScript = MockNativeProcessControlService.class.getResource("/stop_fake_sap.sh").getPath();
         this.startSearcherCommand = "sh " + startScript + " sap_server_d roleType=searcher &";

--- a/elastic-fed/modules/havenask-engine/src/test/java/org/havenask/engine/NativeProcessControlServiceTests.java
+++ b/elastic-fed/modules/havenask-engine/src/test/java/org/havenask/engine/NativeProcessControlServiceTests.java
@@ -59,6 +59,7 @@ public class NativeProcessControlServiceTests extends HavenaskTestCase {
         Environment environment = TestEnvironment.newEnvironment(settings);
         NodeEnvironment nodeEnvironment = new NodeEnvironment(settings, environment);
         nativeProcessControlService = new MockNativeProcessControlService(
+            null,
             clusterService,
             threadPool,
             environment,


### PR DESCRIPTION
searcher重启后会执行_cluster/reroute?retry_failed=true, 不然可能会导致searcher重启但节点还是RED