### PR TITLE
支持search的match all query

### DIFF
--- a/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/index/engine/QueryTransformer.java
+++ b/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/index/engine/QueryTransformer.java
@@ -14,10 +14,11 @@
 
 package org.havenask.engine.index.engine;
 
+import java.io.IOException;
+
+import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 import org.havenask.engine.index.query.ProximaQuery;
-
-import java.io.IOException;
 
 public class QueryTransformer {
 
@@ -34,9 +35,11 @@ public class QueryTransformer {
                 }
             }
             sqlQuery.append("&n=" + proximaQuery.getTopN() + "')");
+        } else if (query instanceof MatchAllDocsQuery) {
+            // do nothing
         } else {
             // TODO reject unsupported DSL
-            throw new IOException("unsupported DSL:" + query);
+            throw new IOException("unsupported DSL query:" + query);
         }
 
         return sqlQuery.toString();

--- a/elastic-fed/modules/havenask-engine/src/test/java/org/havenask/engine/index/engine/QueryTransformerTests.java
+++ b/elastic-fed/modules/havenask-engine/src/test/java/org/havenask/engine/index/engine/QueryTransformerTests.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2021, Alibaba Group;
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.havenask.engine.index.engine;
+
+import java.io.IOException;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.TermQuery;
+import org.havenask.engine.index.query.HnswQuery;
+import org.havenask.test.HavenaskTestCase;
+
+/**
+ *
+ * public class QueryTransformer {
+ *
+ *     public static String toSql(String table, Query query) throws IOException {
+ *         StringBuilder sqlQuery = new StringBuilder();
+ *         sqlQuery.append("select _id from " + table);
+ *         if (query instanceof ProximaQuery) {
+ *             ProximaQuery proximaQuery = (ProximaQuery) query;
+ *             sqlQuery.append(" where MATCHINDEX('" + proximaQuery.getField() + "', '");
+ *             for (int i = 0; i < proximaQuery.getQueryVector().length; i++) {
+ *                 sqlQuery.append(proximaQuery.getQueryVector()[i]);
+ *                 if (i < proximaQuery.getQueryVector().length - 1) {
+ *                     sqlQuery.append(",");
+ *                 }
+ *             }
+ *             sqlQuery.append("&n=" + proximaQuery.getTopN() + "')");
+ *         } else if (query instanceof MatchAllDocsQuery) {
+ *             // do nothing
+ *         } else {
+ *             // TODO reject unsupported DSL
+ *             throw new IOException("unsupported DSL:" + query);
+ *         }
+ *
+ *         return sqlQuery.toString();
+ *     }
+ * }
+ *
+ */
+
+public class QueryTransformerTests extends HavenaskTestCase {
+    public void testMatchAllDocsQuery() throws IOException {
+        String sql = QueryTransformer.toSql("table", new MatchAllDocsQuery());
+        assertEquals(sql, "select _id from table");
+    }
+
+    /**
+     *
+     *     public HnswQuery(String field, float[] queryVector, int topN, SearchFilter searchFilter, Integer ef,
+     *     Integer maxScanNum) {
+     *         super(field, queryVector, searchFilter, topN);
+     *         this.ef = (ef == null ? DEFAULT_EF : ef);
+     *         this.maxScanNum = (maxScanNum == null ? DEFAULT_MAX_SCAN_NUM : maxScanNum);
+     *     }
+     *
+     */
+
+    public void testProximaQuery() throws IOException {
+        HnswQuery hnswQuery = new HnswQuery("field", new float[] { 1.0f, 2.0f }, 20, null, null, null);
+        String sql = QueryTransformer.toSql("table", hnswQuery);
+        assertEquals(sql, "select _id from table where MATCHINDEX('field', '1.0,2.0&n=20')");
+    }
+
+    public void testUnsupportedDSL() throws IOException {
+        try {
+            QueryTransformer.toSql("table", new TermQuery(new Term("field", "value")));
+            fail();
+        } catch (IOException e) {
+            assertEquals(e.getMessage(), "unsupported DSL query:field:value");
+        }
+    }
+}

--- a/elastic-fed/modules/havenask-engine/src/test/java/org/havenask/engine/index/engine/QueryTransformerTests.java
+++ b/elastic-fed/modules/havenask-engine/src/test/java/org/havenask/engine/index/engine/QueryTransformerTests.java
@@ -22,52 +22,11 @@ import org.apache.lucene.search.TermQuery;
 import org.havenask.engine.index.query.HnswQuery;
 import org.havenask.test.HavenaskTestCase;
 
-/**
- *
- * public class QueryTransformer {
- *
- *     public static String toSql(String table, Query query) throws IOException {
- *         StringBuilder sqlQuery = new StringBuilder();
- *         sqlQuery.append("select _id from " + table);
- *         if (query instanceof ProximaQuery) {
- *             ProximaQuery proximaQuery = (ProximaQuery) query;
- *             sqlQuery.append(" where MATCHINDEX('" + proximaQuery.getField() + "', '");
- *             for (int i = 0; i < proximaQuery.getQueryVector().length; i++) {
- *                 sqlQuery.append(proximaQuery.getQueryVector()[i]);
- *                 if (i < proximaQuery.getQueryVector().length - 1) {
- *                     sqlQuery.append(",");
- *                 }
- *             }
- *             sqlQuery.append("&n=" + proximaQuery.getTopN() + "')");
- *         } else if (query instanceof MatchAllDocsQuery) {
- *             // do nothing
- *         } else {
- *             // TODO reject unsupported DSL
- *             throw new IOException("unsupported DSL:" + query);
- *         }
- *
- *         return sqlQuery.toString();
- *     }
- * }
- *
- */
-
 public class QueryTransformerTests extends HavenaskTestCase {
     public void testMatchAllDocsQuery() throws IOException {
         String sql = QueryTransformer.toSql("table", new MatchAllDocsQuery());
         assertEquals(sql, "select _id from table");
     }
-
-    /**
-     *
-     *     public HnswQuery(String field, float[] queryVector, int topN, SearchFilter searchFilter, Integer ef,
-     *     Integer maxScanNum) {
-     *         super(field, queryVector, searchFilter, topN);
-     *         this.ef = (ef == null ? DEFAULT_EF : ef);
-     *         this.maxScanNum = (maxScanNum == null ? DEFAULT_MAX_SCAN_NUM : maxScanNum);
-     *     }
-     *
-     */
 
     public void testProximaQuery() throws IOException {
         HnswQuery hnswQuery = new HnswQuery("field", new float[] { 1.0f, 2.0f }, 20, null, null, null);


### PR DESCRIPTION
支持search的match all query，这样在search接口不传DSL时，能查出数据