### PR TITLE
修复反复创建相同索引的异常case

### DIFF
--- a/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/MetaDataSyncer.java
+++ b/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/MetaDataSyncer.java
@@ -183,59 +183,59 @@ public class MetaDataSyncer extends AbstractLifecycleComponent {
                 return;
             }
 
-            // 同步元数据,触发条件:
-            // 1. pending为true
-            // 2. synced为false
-            // 3. syncTimes小于MAX_SYNC_TIMES
-            if (pending.getAndSet(false) == true || synced.get() == false || syncTimes > MAX_SYNC_TIMES) {
-                // update heartbeat target
-                LOGGER.info("update heartbeat target, synced: {}, pending: {}, syncTimes: {}", synced.get(), pending.get(), syncTimes);
+            synchronized (this) {
+                // 同步元数据,触发条件:
+                // 1. pending为true
+                // 2. synced为false
+                // 3. syncTimes小于MAX_SYNC_TIMES
+                if (pending.getAndSet(false) == true || synced.get() == false || syncTimes > MAX_SYNC_TIMES) {
+                    // update heartbeat target
+                    LOGGER.info("update heartbeat target, synced: {}, pending: {}, syncTimes: {}", synced.get(), pending.get(), syncTimes);
 
-                try {
-                    // TODO qrs每次request都变化,此处是否正常同步成功
-                    UpdateHeartbeatTargetRequest qrsTargetRequest = createQrsUpdateHeartbeatTargetRequest();
-                    HeartbeatTargetResponse qrsResponse = qrsClient.updateHeartbeatTarget(qrsTargetRequest);
+                    try {
+                        UpdateHeartbeatTargetRequest qrsTargetRequest = createQrsUpdateHeartbeatTargetRequest();
+                        HeartbeatTargetResponse qrsResponse = qrsClient.updateHeartbeatTarget(qrsTargetRequest);
 
-                    UpdateHeartbeatTargetRequest searcherTargetRequest = createSearcherUpdateHeartbeatTargetRequest();
-                    HeartbeatTargetResponse searcherResponse = searcherClient.updateHeartbeatTarget(searcherTargetRequest);
+                        UpdateHeartbeatTargetRequest searcherTargetRequest = createSearcherUpdateHeartbeatTargetRequest();
+                        HeartbeatTargetResponse searcherResponse = searcherClient.updateHeartbeatTarget(searcherTargetRequest);
 
-                    // TODO check target info equals method
-                    boolean qrsEquals = qrsTargetRequest.getTargetInfo().equals(qrsResponse.getSignature());
-                    boolean searcherEquals = searcherTargetRequest.getTargetInfo().equals(searcherResponse.getSignature());
-                    if (false == qrsEquals) {
-                        LOGGER.trace(
-                            "update qrs heartbeat target failed, qrsTargetRequest: {}, qrsResponse: {}",
-                            Strings.toString(qrsTargetRequest),
-                            Strings.toString(qrsResponse)
-                        );
+                        boolean qrsEquals = qrsTargetRequest.getTargetInfo().equals(qrsResponse.getSignature());
+                        boolean searcherEquals = searcherTargetRequest.getTargetInfo().equals(searcherResponse.getSignature());
+                        if (false == qrsEquals) {
+                            LOGGER.trace(
+                                "update qrs heartbeat target failed, qrsTargetRequest: {}, qrsResponse: {}",
+                                Strings.toString(qrsTargetRequest),
+                                Strings.toString(qrsResponse)
+                            );
+                        }
+
+                        if (false == searcherEquals) {
+                            LOGGER.trace(
+                                "update searcher heartbeat target failed, searcherTargetRequest: {}, searcherResponse: {}",
+                                Strings.toString(searcherTargetRequest),
+                                Strings.toString(searcherResponse)
+                            );
+                        }
+
+                        if (qrsEquals && searcherEquals) {
+                            LOGGER.info("update heartbeat target success");
+
+                            synced.set(true);
+                            searcherTargetInfo.set(searcherResponse.getCustomInfo());
+                            syncTimes = 0;
+                            // 在每次同步成功时更新两个randomVersion
+                            randomVersion = random.nextInt(100000) + 1;
+                            generalSqlRandomVersion = random.nextInt(100000) + 1;
+                            return;
+                        }
+                    } catch (Throwable e) {
+                        LOGGER.error("update heartbeat target failed", e);
                     }
 
-                    if (false == searcherEquals) {
-                        LOGGER.trace(
-                            "update searcher heartbeat target failed, searcherTargetRequest: {}, searcherResponse: {}",
-                            Strings.toString(searcherTargetRequest),
-                            Strings.toString(searcherResponse)
-                        );
-                    }
-
-                    if (qrsEquals && searcherEquals) {
-                        LOGGER.info("update heartbeat target success");
-
-                        synced.set(true);
-                        searcherTargetInfo.set(searcherResponse.getCustomInfo());
-                        syncTimes = 0;
-                        // 在每次同步成功时更新两个randomVersion
-                        randomVersion = random.nextInt(100000) + 1;
-                        generalSqlRandomVersion = random.nextInt(100000) + 1;
-                        return;
-                    }
-                } catch (Throwable e) {
-                    LOGGER.error("update heartbeat target failed", e);
+                    synced.set(false);
+                } else {
+                    syncTimes++;
                 }
-
-                synced.set(false);
-            } else {
-                syncTimes++;
             }
         }
 
@@ -255,8 +255,9 @@ public class MetaDataSyncer extends AbstractLifecycleComponent {
     /**
      * 设置sync metadata
      */
-    public void setPendingSync() {
+    public synchronized void setPendingSync() {
         pending.set(true);
+        searcherTargetInfo.set(null);
     }
 
     public UpdateHeartbeatTargetRequest createQrsUpdateHeartbeatTargetRequest() throws IOException {


### PR DESCRIPTION
fix：https://github.com/alibaba/havenask-federation/issues/263
元数据发生变更时，先清掉searcherTargetInfo，防止获取到之前的searcherTargetInfo，误判为searcher已经更新成功。