### PR TITLE
javaRestTest测试用例优化，修复了一些更新后相关测试存在的问题

### DIFF
--- a/elastic-fed/modules/havenask-engine/src/javaRestTest/java/org/havenask/engine/AbstractHavenaskRestTestCase.java
+++ b/elastic-fed/modules/havenask-engine/src/javaRestTest/java/org/havenask/engine/AbstractHavenaskRestTestCase.java
@@ -82,7 +82,7 @@ public abstract class AbstractHavenaskRestTestCase extends HavenaskRestTestCase 
         }, 2, TimeUnit.MINUTES);
     }
 
-    //TODO 写入后立刻查询有可能会查不到doc，因此等待一会儿，可能是由havenask写入队列造成的，待确认
+    // TODO 写入后立刻查询有可能会查不到doc，因此等待一会儿，可能是由havenask写入队列造成的，待确认
     protected void waitResponseExists(String index, String id) throws Exception {
         assertBusy(() -> {
             GetResponse getResponse = getDocById(index, id);

--- a/elastic-fed/modules/havenask-engine/src/javaRestTest/java/org/havenask/engine/AbstractHavenaskRestTestCase.java
+++ b/elastic-fed/modules/havenask-engine/src/javaRestTest/java/org/havenask/engine/AbstractHavenaskRestTestCase.java
@@ -16,10 +16,27 @@ package org.havenask.engine;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.concurrent.TimeUnit;
 
+import org.havenask.action.admin.cluster.health.ClusterHealthRequest;
+import org.havenask.action.admin.cluster.health.ClusterHealthResponse;
+import org.havenask.action.admin.indices.delete.DeleteIndexRequest;
+import org.havenask.action.delete.DeleteRequest;
+import org.havenask.action.get.GetRequest;
+import org.havenask.action.get.GetResponse;
+import org.havenask.action.index.IndexRequest;
+import org.havenask.action.update.UpdateRequest;
+import org.havenask.client.RequestOptions;
 import org.havenask.client.RestClient;
 import org.havenask.client.RestHighLevelClient;
+import org.havenask.client.ha.SqlRequest;
+import org.havenask.client.ha.SqlResponse;
+import org.havenask.client.indices.CreateIndexRequest;
+import org.havenask.client.indices.GetIndexRequest;
+import org.havenask.cluster.health.ClusterHealthStatus;
 import org.havenask.common.settings.Settings;
+import org.havenask.common.xcontent.XContentBuilder;
+import org.havenask.common.xcontent.XContentType;
 import org.havenask.core.internal.io.IOUtils;
 import org.havenask.search.SearchModule;
 import org.havenask.test.rest.HavenaskRestTestCase;
@@ -55,5 +72,68 @@ public abstract class AbstractHavenaskRestTestCase extends HavenaskRestTestCase 
         private HighLevelClient(RestClient restClient) {
             super(restClient, (client) -> {}, new SearchModule(Settings.EMPTY, false, Collections.emptyList()).getNamedXContents());
         }
+    }
+
+    protected void waitIndexGreen(String index) throws Exception {
+        assertBusy(() -> {
+            ClusterHealthResponse clusterHealthResponse = highLevelClient().cluster()
+                .health(new ClusterHealthRequest(index), RequestOptions.DEFAULT);
+            assertEquals(ClusterHealthStatus.GREEN, clusterHealthResponse.getStatus());
+        }, 2, TimeUnit.MINUTES);
+    }
+
+    //TODO 写入后立刻查询有可能会查不到doc，因此等待一会儿，可能是由havenask写入队列造成的，待确认
+    protected void waitResponseExists(String index, String id) throws Exception {
+        assertBusy(() -> {
+            GetResponse getResponse = getDocById(index, id);
+            assertEquals(true, getResponse.isExists());
+        }, 10, TimeUnit.SECONDS);
+    }
+
+    @SuppressWarnings("unchecked")
+    protected boolean createTestIndex(String index, Settings settings, Object map) throws Exception {
+        CreateIndexRequest createIndexRequest = new CreateIndexRequest(index);
+        if (settings != null) {
+            createIndexRequest.settings(settings);
+        }
+        if (map != null) {
+            if (map instanceof java.util.Map) {
+                createIndexRequest.mapping((java.util.Map<String, ?>) map);
+            } else if (map instanceof XContentBuilder) {
+                createIndexRequest.mapping((XContentBuilder) map);
+            } else {
+                throw new IllegalArgumentException("Unsupported map type: " + map.getClass());
+            }
+        }
+        return highLevelClient().indices().create(createIndexRequest, RequestOptions.DEFAULT).isAcknowledged();
+    }
+
+    protected void deleteAndHeadIndex(String index) throws Exception {
+        assertTrue(highLevelClient().indices().delete(new DeleteIndexRequest(index), RequestOptions.DEFAULT).isAcknowledged());
+        assertEquals(false, highLevelClient().indices().exists(new GetIndexRequest(index), RequestOptions.DEFAULT));
+    }
+
+    protected void putDoc(String index, String id, java.util.Map<String, ?> source) throws Exception {
+        highLevelClient().index(new IndexRequest(index).id(id).source(source, XContentType.JSON), RequestOptions.DEFAULT);
+    }
+
+    protected void putDoc(String index, java.util.Map<String, ?> source) throws Exception {
+        highLevelClient().index(new IndexRequest(index).source(source, XContentType.JSON), RequestOptions.DEFAULT);
+    }
+
+    protected GetResponse getDocById(String index, String id) throws Exception {
+        return highLevelClient().get(new GetRequest(index, id), RequestOptions.DEFAULT);
+    }
+
+    protected SqlResponse getSqlResponse(String sqlStr) throws Exception {
+        return highLevelClient().havenask().sql(new SqlRequest(sqlStr), RequestOptions.DEFAULT);
+    }
+
+    protected void updateDoc(String index, String id, java.util.Map<String, Object> source) throws Exception {
+        highLevelClient().update(new UpdateRequest(index, id).doc(source, XContentType.JSON), RequestOptions.DEFAULT);
+    }
+
+    protected void deleteDoc(String index, String id) throws Exception {
+        highLevelClient().delete(new DeleteRequest(index, id), RequestOptions.DEFAULT);
     }
 }

--- a/elastic-fed/modules/havenask-engine/src/javaRestTest/java/org/havenask/engine/BasicIT.java
+++ b/elastic-fed/modules/havenask-engine/src/javaRestTest/java/org/havenask/engine/BasicIT.java
@@ -14,10 +14,13 @@
 
 package org.havenask.engine;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.havenask.action.admin.cluster.health.ClusterHealthRequest;
 import org.havenask.action.admin.cluster.health.ClusterHealthResponse;
 import org.havenask.action.admin.indices.delete.DeleteIndexRequest;
@@ -40,8 +43,32 @@ import org.havenask.common.xcontent.XContentHelper;
 import org.havenask.common.xcontent.XContentType;
 import org.havenask.engine.index.engine.EngineSettings;
 import org.havenask.index.mapper.MapperService;
+import org.junit.AfterClass;
 
 public class BasicIT extends AbstractHavenaskRestTestCase {
+
+    // static logger
+    private static final Logger logger = LogManager.getLogger(BasicIT.class);
+    private static final String[] BasicITIndices = {
+        "index_crud",
+        "index_index_method",
+        "create_and_delete_test",
+        "create_and_delete_test" };
+
+    @AfterClass
+    public static void cleanIndices() {
+        try {
+            for (String index : BasicITIndices) {
+                if (highLevelClient().indices().exists(new GetIndexRequest(index), RequestOptions.DEFAULT)) {
+                    highLevelClient().indices().delete(new DeleteIndexRequest(index), RequestOptions.DEFAULT);
+                    logger.info("clean index {}", index);
+                }
+            }
+        } catch (IOException e) {
+            logger.error("clean index failed", e);
+        }
+    }
+
     public void testCRUD() throws Exception {
         String index = "index_crud";
         assertTrue(

--- a/elastic-fed/modules/havenask-engine/src/javaRestTest/java/org/havenask/engine/DocIT.java
+++ b/elastic-fed/modules/havenask-engine/src/javaRestTest/java/org/havenask/engine/DocIT.java
@@ -49,7 +49,7 @@ import org.junit.AfterClass;
 public class DocIT extends AbstractHavenaskRestTestCase {
     // static logger
     private static final Logger logger = LogManager.getLogger(DocIT.class);
-    private static final String[] DocITIndices = { "index_doc_method", "index_multi_data_type", "illegal_vector_test" };
+    private static final String[] DocITIndices = { "index_doc_method", "index_multi_data_type", "illegal_vector_test", "update_doc_test" };
 
     @AfterClass
     public static void cleanIndices() {

--- a/elastic-fed/modules/havenask-engine/src/javaRestTest/java/org/havenask/engine/DocIT.java
+++ b/elastic-fed/modules/havenask-engine/src/javaRestTest/java/org/havenask/engine/DocIT.java
@@ -50,6 +50,10 @@ public class DocIT extends AbstractHavenaskRestTestCase {
     // static logger
     private static final Logger logger = LogManager.getLogger(DocIT.class);
     private static final String[] DocITIndices = { "index_doc_method", "index_multi_data_type", "illegal_vector_test", "update_doc_test" };
+    private static final int TEST_DOC_METHOD_INDEX_POS = 0;
+    private static final int TEST_MULTI_DATA_TYPE_INDEX_POS = 1;
+    private static final int TEST_ILLEGAL_VECTOR_TEST_INDEX_POS = 2;
+    private static final int TEST_UPDATE_DOC_TEST_INDEX_POS = 3;
 
     @AfterClass
     public static void cleanIndices() {
@@ -67,7 +71,7 @@ public class DocIT extends AbstractHavenaskRestTestCase {
 
     // test document api, PUT/POST/DELETE and bulk
     public void testDocMethod() throws Exception {
-        String index = "index_doc_method";
+        String index = DocITIndices[TEST_DOC_METHOD_INDEX_POS];
         // create index
         Settings settings = Settings.builder()
             .put(EngineSettings.ENGINE_TYPE_SETTING.getKey(), EngineSettings.ENGINE_HAVENASK)
@@ -175,7 +179,7 @@ public class DocIT extends AbstractHavenaskRestTestCase {
 
     // test common data type(int, double, boolean, date, text, keyword, array)
     public void testMultiDataType() throws Exception {
-        String index = "index_multi_data_type";
+        String index = DocITIndices[TEST_MULTI_DATA_TYPE_INDEX_POS];
         // create index with multi data type
         Settings settings = Settings.builder()
             .put(EngineSettings.ENGINE_TYPE_SETTING.getKey(), EngineSettings.ENGINE_HAVENASK)
@@ -275,7 +279,7 @@ public class DocIT extends AbstractHavenaskRestTestCase {
     }
 
     public void testIllegalVectorParams() throws Exception {
-        String index = "illegal_vector_test";
+        String index = DocITIndices[TEST_ILLEGAL_VECTOR_TEST_INDEX_POS];
         String fieldName = "vector";
         int vectorDims = 2;
         String similarity = "dot_product";
@@ -324,7 +328,7 @@ public class DocIT extends AbstractHavenaskRestTestCase {
     }
 
     public void testUpdateDoc() throws Exception {
-        String index = "update_doc_test";
+        String index = DocITIndices[TEST_UPDATE_DOC_TEST_INDEX_POS];
         int loopCount = 10;
 
         assertTrue(

--- a/elastic-fed/modules/havenask-engine/src/javaRestTest/java/org/havenask/engine/DocIT.java
+++ b/elastic-fed/modules/havenask-engine/src/javaRestTest/java/org/havenask/engine/DocIT.java
@@ -284,7 +284,7 @@ public class DocIT extends AbstractHavenaskRestTestCase {
 
         // create index
         assertTrue(
-                createTestIndex(
+            createTestIndex(
                 index,
                 Settings.builder()
                     .put("index.number_of_shards", 1)
@@ -327,15 +327,16 @@ public class DocIT extends AbstractHavenaskRestTestCase {
         String index = "update_doc_test";
         int loopCount = 10;
 
-        assertTrue(createTestIndex(index,
+        assertTrue(
+            createTestIndex(
+                index,
                 Settings.builder()
-                        .put("index.number_of_shards", 1)
-                        .put("index.number_of_replicas", 0)
-                        .put(EngineSettings.ENGINE_TYPE_SETTING.getKey(), EngineSettings.ENGINE_HAVENASK)
-                        .build(),
-                Map.of(
-                        "properties",
-                        Map.of("seq", Map.of("type", "integer"))))
+                    .put("index.number_of_shards", 1)
+                    .put("index.number_of_replicas", 0)
+                    .put(EngineSettings.ENGINE_TYPE_SETTING.getKey(), EngineSettings.ENGINE_HAVENASK)
+                    .build(),
+                Map.of("properties", Map.of("seq", Map.of("type", "integer")))
+            )
         );
 
         waitIndexGreen(index);

--- a/elastic-fed/modules/havenask-engine/src/javaRestTest/java/org/havenask/engine/DocIT.java
+++ b/elastic-fed/modules/havenask-engine/src/javaRestTest/java/org/havenask/engine/DocIT.java
@@ -113,6 +113,7 @@ public class DocIT extends AbstractHavenaskRestTestCase {
         putDoc(index, Map.of("seq", 4, "content", "欢迎使用4", "time", "20230715"));
 
         /// get index data count
+        waitSqlResponseExists("select count(*) from " + index, 1);
         SqlResponse sqlResponse = getSqlResponse("select count(*) from " + index);
 
         assertEquals(1, sqlResponse.getRowCount());
@@ -262,6 +263,7 @@ public class DocIT extends AbstractHavenaskRestTestCase {
         String sqlStr = "select * from "
             + index
             + " where my_keyword='keyword' AND my_text='text' AND my_integer=1 AND my_double=1.5 AND my_boolean='T' ";
+        waitSqlResponseExists(sqlStr, 1);
         SqlResponse bulkSqlResponse = getSqlResponse(sqlStr);
         java.util.Map<String, Integer> dataIndexMap = new HashMap<>();
         for (int i = 0; i < bulkSqlResponse.getSqlResult().getColumnName().length; i++) {
@@ -393,5 +395,12 @@ public class DocIT extends AbstractHavenaskRestTestCase {
             .getJSONObject("store")
             .getLong("size_in_bytes");
         assertTrue(storeSize >= 10240L);
+    }
+
+    protected void waitSqlResponseExists(String sqlStr, int expectedRowCount) throws Exception {
+        assertBusy(() -> {
+            SqlResponse sqlResponse = getSqlResponse(sqlStr);
+            assertEquals(expectedRowCount, sqlResponse.getRowCount());
+        }, 10, TimeUnit.SECONDS);
     }
 }

--- a/elastic-fed/modules/havenask-engine/src/javaRestTest/java/org/havenask/engine/FlushIT.java
+++ b/elastic-fed/modules/havenask-engine/src/javaRestTest/java/org/havenask/engine/FlushIT.java
@@ -29,7 +29,6 @@
 package org.havenask.engine;
 
 import java.io.IOException;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
@@ -276,11 +275,13 @@ public class FlushIT extends AbstractHavenaskRestTestCase {
     }
 
     private void checkLocalPoint(String index, Set<Long> expectedCheckpontValue) throws Exception {
-        assertBusy(()-> {
+        assertBusy(() -> {
             long tempLocalCheckpoint = getLocalCheckpoint(index);
-            assertTrue("checkpoint should be "+ expectedCheckpontValue.toString() + ", but get: " + tempLocalCheckpoint,
-                    expectedCheckpontValue.contains(tempLocalCheckpoint));
+            assertTrue(
+                "checkpoint should be " + expectedCheckpontValue.toString() + ", but get: " + tempLocalCheckpoint,
+                expectedCheckpontValue.contains(tempLocalCheckpoint)
+            );
         }, 10, TimeUnit.SECONDS);
-        logger.info("checkpoint should be {}, checkpoint is {}", expectedCheckpontValue.toString(),getLocalCheckpoint(index));
+        logger.info("checkpoint should be {}, checkpoint is {}", expectedCheckpontValue.toString(), getLocalCheckpoint(index));
     }
 }

--- a/elastic-fed/modules/havenask-engine/src/javaRestTest/java/org/havenask/engine/MappingIT.java
+++ b/elastic-fed/modules/havenask-engine/src/javaRestTest/java/org/havenask/engine/MappingIT.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
 import org.havenask.action.admin.cluster.health.ClusterHealthRequest;
@@ -171,20 +172,20 @@ public class MappingIT extends AbstractHavenaskRestTestCase {
         String index = "index_vector_data";
         String fieldName = "image";
         int vectorDims = 2;
+        String similarity = "L2_NORM";
 
+        final String[] types = { "hnsw", "qc", "linear" };
+        final String[] typesStr = { "HNSW", "QC", "LINEAR" };
         final String[] indexOptionNames = new String[] {
             "type",
             "embedding_delimiter",
-            "distance_type",
             "major_order",
             "ignore_invalid_doc",
             "enable_recall_report",
             "is_embedding_saved",
             "min_scan_doc_cnt",
             "linear_build_threshold" };
-        final String[] types = { "hnsw", "qc", "linear" };
-        final String[] typesStr = { "HNSW", "QC", "LINEAR" };
-        final String[] indexOptionValues = new String[] { "", ",", "InnerProduct", "row", "true", "true", "true", "20000", "500" };
+        final String[] indexOptionValues = new String[] { "", ",", "row", "true", "true", "true", "20000", "500" };
 
         final String[][] searchIndexParamsNames = new String[][] {
             new String[] { "proxima.hnsw.searcher.ef" },
@@ -224,18 +225,26 @@ public class MappingIT extends AbstractHavenaskRestTestCase {
             { 8.8f, 8.8f } };
 
         String[] resSourceAsString = new String[] {
-            "{\"image\":[8.8,8.8]}",
-            "{\"image\":[7.7,7.7]}",
-            "{\"image\":[6.6,6.6]}",
-            "{\"image\":[5.5,5.5]}",
-            "{\"image\":[4.4,4.4]}",
-            "{\"image\":[3.3,3.3]}",
             "{\"image\":[2.2,2.2]}",
-            "{\"image\":[1.1,1.1]}" };
+            "{\"image\":[1.1,1.1]}",
+            "{\"image\":[3.3,3.3]}",
+            "{\"image\":[4.4,4.4]}",
+            "{\"image\":[5.5,5.5]}",
+            "{\"image\":[6.6,6.6]}",
+            "{\"image\":[7.7,7.7]}",
+            "{\"image\":[8.8,8.8]}" };
 
         float delta = 0.0001F;
-        float expectedMaxScore = 35.2F;
-        float[] expectedScores = new float[] { 35.2F, 30.8F, 26.4F, 22.0F, 17.6F, 13.2F, 8.8F, 4.4F };
+        float expectedMaxScore = 0.6329114F;
+        float[] expectedScores = new float[] {
+            0.6329114F,
+            0.32051283F,
+            0.20491804F,
+            0.07680491F,
+            0.03846154F,
+            0.02282063F,
+            0.015042119F,
+            0.010640562F };
 
         for (int type = 0; type < types.length; type++) {
             indexOptionValues[TYPE_POS] = types[type];
@@ -254,6 +263,7 @@ public class MappingIT extends AbstractHavenaskRestTestCase {
                                 createVectorMapping(
                                     vectorDims,
                                     fieldName,
+                                    similarity,
                                     indexOptionNames,
                                     indexOptionValues,
                                     searchIndexParamsNames[type],
@@ -277,6 +287,7 @@ public class MappingIT extends AbstractHavenaskRestTestCase {
             java.util.Map<String, Object> expectedMapping = createExpectedMapping(
                 vectorDims,
                 fieldName,
+                similarity,
                 indexOptionNames,
                 indexOptionValues,
                 searchIndexParamsNames[type],
@@ -328,15 +339,13 @@ public class MappingIT extends AbstractHavenaskRestTestCase {
     /**
      *     "dimension": "2",
      *     "embedding_delimiter": ",",
-     *     "distance_type": "InnerProduct",
      *     "builder_name": "QcBuilder",
      *     "searcher_name": "QcSearcher",
      *     "build_index_params": "{}",
      *     "search_index_params": "{\"proxima.qc.searcher.scan_ratio\":0.10}",
      *     "linear_build_threshold": "10000",
      *     "min_scan_doc_cnt":"20000",
-     *     "enable_recall_report": "true",
-     *     "enable_rt_build" : "false"
+     *     "enable_recall_report": "true"
      */
     @SuppressWarnings("unchecked")
     public void testVectorDataWithPartialParams() throws Exception {
@@ -344,16 +353,16 @@ public class MappingIT extends AbstractHavenaskRestTestCase {
         String index = "index_vector_data_with_partial_params";
         String fieldName = "image";
         int vectorDims = 2;
+        String similarity = "L2_NORM";
 
         final String[] indexOptionNames = new String[] {
             "type",
             "embedding_delimiter",
-            "distance_type",
             "linear_build_threshold",
             "enable_recall_report",
             "min_scan_doc_cnt", };
 
-        final String[] indexOptionValues = new String[] { "qc", ",", "InnerProduct", "10000", "true", "20000" };
+        final String[] indexOptionValues = new String[] { "qc", ",", "10000", "true", "20000" };
 
         final String[] searchIndexParamsNames = new String[] { "proxima.qc.searcher.scan_ratio" };
         final String[] searchIndexParamsValues = new String[] { "0.01" };
@@ -371,18 +380,26 @@ public class MappingIT extends AbstractHavenaskRestTestCase {
             { 8.8f, 8.8f } };
 
         String[] resSourceAsString = new String[] {
-            "{\"image\":[8.8,8.8]}",
-            "{\"image\":[7.7,7.7]}",
-            "{\"image\":[6.6,6.6]}",
-            "{\"image\":[5.5,5.5]}",
-            "{\"image\":[4.4,4.4]}",
-            "{\"image\":[3.3,3.3]}",
             "{\"image\":[2.2,2.2]}",
-            "{\"image\":[1.1,1.1]}" };
+            "{\"image\":[1.1,1.1]}",
+            "{\"image\":[3.3,3.3]}",
+            "{\"image\":[4.4,4.4]}",
+            "{\"image\":[5.5,5.5]}",
+            "{\"image\":[6.6,6.6]}",
+            "{\"image\":[7.7,7.7]}",
+            "{\"image\":[8.8,8.8]}" };
 
         float delta = 0.0001F;
-        float expectedMaxScore = 35.2F;
-        float[] expectedScores = new float[] { 35.2F, 30.8F, 26.4F, 22.0F, 17.6F, 13.2F, 8.8F, 4.4F };
+        float expectedMaxScore = 0.6329114F;
+        float[] expectedScores = new float[] {
+            0.6329114F,
+            0.32051283F,
+            0.20491804F,
+            0.07680491F,
+            0.03846154F,
+            0.02282063F,
+            0.015042119F,
+            0.010640562F };
 
         // create index
         assertTrue(
@@ -399,6 +416,7 @@ public class MappingIT extends AbstractHavenaskRestTestCase {
                             createVectorMapping(
                                 vectorDims,
                                 fieldName,
+                                similarity,
                                 indexOptionNames,
                                 indexOptionValues,
                                 searchIndexParamsNames,
@@ -422,6 +440,7 @@ public class MappingIT extends AbstractHavenaskRestTestCase {
         java.util.Map<String, Object> expectedMapping = createExpectedMapping(
             vectorDims,
             fieldName,
+            similarity,
             indexOptionNames,
             indexOptionValues,
             searchIndexParamsNames,
@@ -467,9 +486,120 @@ public class MappingIT extends AbstractHavenaskRestTestCase {
         assertEquals(false, highLevelClient().indices().exists(new GetIndexRequest(index), RequestOptions.DEFAULT));
     }
 
+    public void testIllegalVectorParamsCheck() throws Exception {
+        String index = "index_test_illegal_vector_params_check";
+        String fieldName = "image";
+        int vectorDims = 2;
+        String similarity = "DOT_PRODUCT";
+
+        int dataNum = 3;
+        String[] ids = { "1", "2", "3" };
+        float[][] images = new float[][] { { 0.6f, 0.8f }, { 0.8f, 0.6f }, { 1.0f, 0f } };
+
+        float[] wrongVector = new float[] { 1f, 1f };
+
+        String[] resSourceAsString = new String[] { "{\"image\":[0.6,0.8]}", "{\"image\":[0.8,0.6]}", "{\"image\":[1.0,0.0]}" };
+
+        float delta = 0.0001F;
+        float expectedMaxScore = 1F;
+        float[] expectedScores = new float[] { 1F, 0.98F, 0.8F };
+
+        // create index
+        assertTrue(
+            highLevelClient().indices()
+                .create(
+                    new CreateIndexRequest(index).settings(
+                        Settings.builder()
+                            .put(EngineSettings.ENGINE_TYPE_SETTING.getKey(), EngineSettings.ENGINE_HAVENASK)
+                            .put("index.number_of_shards", 1)
+                            .put("index.number_of_replicas", 0)
+                            .build()
+                    ).mapping(createVectorMapping(vectorDims, fieldName, similarity, null, null, null, null, null, null)),
+                    RequestOptions.DEFAULT
+                )
+                .isAcknowledged()
+        );
+        assertBusy(() -> {
+            ClusterHealthResponse clusterHealthResponse = highLevelClient().cluster()
+                .health(new ClusterHealthRequest(index), RequestOptions.DEFAULT);
+            assertEquals(clusterHealthResponse.getStatus(), ClusterHealthStatus.GREEN);
+        }, 2, TimeUnit.MINUTES);
+
+        // get mapping
+        java.util.Map<String, Object> expectedMapping = createExpectedMapping(
+            vectorDims,
+            fieldName,
+            similarity,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        );
+        java.util.Map<String, Object> actualMapping = highLevelClient().indices()
+            .get(new GetIndexRequest(index), RequestOptions.DEFAULT)
+            .getMappings()
+            .get(index)
+            .getSourceAsMap();
+        assertEquals(expectedMapping.toString(), actualMapping.toString());
+
+        // put doc
+        for (int i = 0; i < dataNum; i++) {
+            highLevelClient().index(
+                new IndexRequest(index).id(ids[i]).source(Map.of(fieldName, images[i]), XContentType.JSON),
+                RequestOptions.DEFAULT
+            );
+        }
+        try {
+            highLevelClient().index(
+                new IndexRequest(index).id("4").source(Map.of(fieldName, wrongVector), XContentType.JSON),
+                RequestOptions.DEFAULT
+            );
+            fail("Should throw exception");
+        } catch (Exception e) {
+            assertTrue(e.getCause().toString().contains("The [dot_product] similarity can only be used with unit-length vectors."));
+        }
+
+        // get data with _search
+        try {
+            SearchRequest wrongSearchRequest = new SearchRequest(index);
+            SearchSourceBuilder wrongSearchSourceBuilder = new SearchSourceBuilder();
+            HnswQueryBuilder wrongHnswQueryBuilder = new HnswQueryBuilder(fieldName, new float[] { 1f, 2f }, 10);
+            wrongSearchSourceBuilder.query(wrongHnswQueryBuilder);
+            wrongSearchRequest.source(wrongSearchSourceBuilder);
+        } catch (Exception e) {
+            assertTrue(e.getCause().toString().contains("The [dot_product] similarity can only be used with unit-length vectors."));
+        }
+
+        SearchRequest searchRequest = new SearchRequest(index);
+        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+        HnswQueryBuilder hnswQueryBuilder = new HnswQueryBuilder(fieldName, new float[] { 0.6f, 0.8f }, 10);
+        searchSourceBuilder.query(hnswQueryBuilder);
+        searchRequest.source(searchSourceBuilder);
+
+        // 执行查询请求并获取相应结果
+        assertBusy(() -> {
+            SearchResponse searchResponse = highLevelClient().search(searchRequest, RequestOptions.DEFAULT);
+            assertEquals(dataNum, searchResponse.getHits().getTotalHits().value);
+        }, 10, TimeUnit.SECONDS);
+        SearchResponse searchResponse = highLevelClient().search(searchRequest, RequestOptions.DEFAULT);
+        assertEquals(dataNum, searchResponse.getHits().getTotalHits().value);
+        assertEquals(expectedMaxScore, searchResponse.getHits().getMaxScore(), delta);
+        for (int i = 0; i < searchResponse.getHits().getHits().length; i++) {
+            assertEquals(resSourceAsString[i], searchResponse.getHits().getHits()[i].getSourceAsString());
+            assertEquals(expectedScores[i], searchResponse.getHits().getHits()[i].getScore(), delta);
+        }
+
+        // delete index and HEAD index
+        assertTrue(highLevelClient().indices().delete(new DeleteIndexRequest(index), RequestOptions.DEFAULT).isAcknowledged());
+        assertEquals(false, highLevelClient().indices().exists(new GetIndexRequest(index), RequestOptions.DEFAULT));
+    }
+
     private static XContentBuilder createVectorMapping(
         int vectorDims,
         String fieldName,
+        String similarityIn,
         String[] indexOptionNames,
         String[] IndexOptionValues,
         String[] searchIndexParamsNames,
@@ -477,6 +607,7 @@ public class MappingIT extends AbstractHavenaskRestTestCase {
         String[] buildIndexParamsNames,
         String[] buildIndexParamsValues
     ) throws IOException {
+        String similarity = similarityIn.toLowerCase(Locale.getDefault());
         XContentBuilder mappingBuilder = XContentFactory.jsonBuilder();
         mappingBuilder.startObject();
         {
@@ -486,32 +617,34 @@ public class MappingIT extends AbstractHavenaskRestTestCase {
                 {
                     mappingBuilder.field("type", "dense_vector");
                     mappingBuilder.field("dims", vectorDims);
-                    mappingBuilder.field("similarity", "dot_product");
-                    mappingBuilder.startObject("index_options");
-                    {
-                        for (int i = 0; i < indexOptionNames.length; i++) {
-                            mappingBuilder.field(indexOptionNames[i], IndexOptionValues[i]);
-                        }
-                        if (searchIndexParamsValues != null) {
-                            mappingBuilder.startObject("search_index_params");
-                            {
-                                for (int i = 0; i < searchIndexParamsNames.length; i++) {
-                                    mappingBuilder.field(searchIndexParamsNames[i], searchIndexParamsValues[i]);
-                                }
+                    mappingBuilder.field("similarity", similarity);
+                    if (indexOptionNames != null && indexOptionNames.length > 0) {
+                        mappingBuilder.startObject("index_options");
+                        {
+                            for (int i = 0; i < indexOptionNames.length; i++) {
+                                mappingBuilder.field(indexOptionNames[i], IndexOptionValues[i]);
                             }
-                            mappingBuilder.endObject();
-                        }
-                        if (buildIndexParamsValues != null) {
-                            mappingBuilder.startObject("build_index_params");
-                            {
-                                for (int i = 0; i < buildIndexParamsNames.length; i++) {
-                                    mappingBuilder.field(buildIndexParamsNames[i], buildIndexParamsValues[i]);
+                            if (searchIndexParamsValues != null) {
+                                mappingBuilder.startObject("search_index_params");
+                                {
+                                    for (int i = 0; i < searchIndexParamsNames.length; i++) {
+                                        mappingBuilder.field(searchIndexParamsNames[i], searchIndexParamsValues[i]);
+                                    }
                                 }
+                                mappingBuilder.endObject();
                             }
-                            mappingBuilder.endObject();
+                            if (buildIndexParamsValues != null) {
+                                mappingBuilder.startObject("build_index_params");
+                                {
+                                    for (int i = 0; i < buildIndexParamsNames.length; i++) {
+                                        mappingBuilder.field(buildIndexParamsNames[i], buildIndexParamsValues[i]);
+                                    }
+                                }
+                                mappingBuilder.endObject();
+                            }
                         }
+                        mappingBuilder.endObject();
                     }
-                    mappingBuilder.endObject();
                 }
                 mappingBuilder.endObject();
             }
@@ -524,6 +657,7 @@ public class MappingIT extends AbstractHavenaskRestTestCase {
     private static java.util.Map<String, Object> createExpectedMapping(
         int vectorDims,
         String fieldName,
+        String similarity,
         String[] indexOptionNames,
         String[] IndexOptionValues,
         String[] searchIndexParamsNames,
@@ -538,25 +672,27 @@ public class MappingIT extends AbstractHavenaskRestTestCase {
         java.util.Map<String, Object> fieldMap = new HashMap<>();
         properties.put(fieldName, fieldMap);
         fieldMap.put("dims", vectorDims);
-        fieldMap.put("similarity", "DOT_PRODUCT");
+        fieldMap.put("similarity", similarity);
         fieldMap.put("type", "dense_vector");
-        java.util.Map<String, Object> indexOptions = new HashMap<>();
-        fieldMap.put("index_options", indexOptions);
-        for (int i = 0; i < indexOptionNames.length; i++) {
-            indexOptions.put(indexOptionNames[i], IndexOptionValues[i]);
-        }
-        java.util.Map<String, Object> searchIndexParams = new HashMap<>();
-        if (searchIndexParamsNames != null) {
-            indexOptions.put("search_index_params", searchIndexParams);
-            for (int i = 0; i < searchIndexParamsNames.length; i++) {
-                searchIndexParams.put(searchIndexParamsNames[i], searchIndexParamsValues[i]);
+        if (indexOptionNames != null) {
+            java.util.Map<String, Object> indexOptions = new HashMap<>();
+            fieldMap.put("index_options", indexOptions);
+            for (int i = 0; i < indexOptionNames.length; i++) {
+                indexOptions.put(indexOptionNames[i], IndexOptionValues[i]);
             }
-        }
-        java.util.Map<String, Object> buildIndexParams = new HashMap<>();
-        indexOptions.put("build_index_params", buildIndexParams);
-        if (buildIndexParamsNames != null) {
-            for (int i = 0; i < buildIndexParamsNames.length; i++) {
-                buildIndexParams.put(buildIndexParamsNames[i], buildIndexParamsValues[i]);
+            java.util.Map<String, Object> searchIndexParams = new HashMap<>();
+            if (searchIndexParamsNames != null) {
+                indexOptions.put("search_index_params", searchIndexParams);
+                for (int i = 0; i < searchIndexParamsNames.length; i++) {
+                    searchIndexParams.put(searchIndexParamsNames[i], searchIndexParamsValues[i]);
+                }
+            }
+            java.util.Map<String, Object> buildIndexParams = new HashMap<>();
+            indexOptions.put("build_index_params", buildIndexParams);
+            if (buildIndexParamsNames != null) {
+                for (int i = 0; i < buildIndexParamsNames.length; i++) {
+                    buildIndexParams.put(buildIndexParamsNames[i], buildIndexParamsValues[i]);
+                }
             }
         }
         return expectedMapping;

--- a/elastic-fed/modules/havenask-engine/src/javaRestTest/java/org/havenask/engine/MappingIT.java
+++ b/elastic-fed/modules/havenask-engine/src/javaRestTest/java/org/havenask/engine/MappingIT.java
@@ -21,6 +21,8 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.havenask.action.admin.cluster.health.ClusterHealthRequest;
 import org.havenask.action.admin.cluster.health.ClusterHealthResponse;
 import org.havenask.action.admin.indices.delete.DeleteIndexRequest;
@@ -40,8 +42,32 @@ import org.havenask.common.xcontent.XContentType;
 import org.havenask.engine.index.engine.EngineSettings;
 import org.havenask.engine.index.query.HnswQueryBuilder;
 import org.havenask.search.builder.SearchSourceBuilder;
+import org.junit.AfterClass;
 
 public class MappingIT extends AbstractHavenaskRestTestCase {
+    // static logger
+    private static final Logger logger = LogManager.getLogger(BasicIT.class);
+    private static final String[] BasicITIndices = {
+        "index_supported_data_type",
+        "index_unsupported_data_type",
+        "index_vector_data",
+        "index_vector_data_with_partial_params",
+        "index_test_illegal_vector_params_check" };
+
+    @AfterClass
+    public static void cleanIndices() {
+        try {
+            for (String index : BasicITIndices) {
+                if (highLevelClient().indices().exists(new GetIndexRequest(index), RequestOptions.DEFAULT)) {
+                    highLevelClient().indices().delete(new DeleteIndexRequest(index), RequestOptions.DEFAULT);
+                    logger.info("clean index {}", index);
+                }
+            }
+        } catch (IOException e) {
+            logger.error("clean index failed", e);
+        }
+    }
+
     // test supported data type
     public void testSupportedDataType() throws Exception {
         String index = "index_supported_data_type";

--- a/elastic-fed/modules/havenask-engine/src/javaRestTest/java/org/havenask/engine/MappingIT.java
+++ b/elastic-fed/modules/havenask-engine/src/javaRestTest/java/org/havenask/engine/MappingIT.java
@@ -46,18 +46,23 @@ import org.junit.AfterClass;
 
 public class MappingIT extends AbstractHavenaskRestTestCase {
     // static logger
-    private static final Logger logger = LogManager.getLogger(BasicIT.class);
-    private static final String[] BasicITIndices = {
+    private static final Logger logger = LogManager.getLogger(MappingIT.class);
+    private static final String[] MappingITIndices = {
         "index_supported_data_type",
         "index_unsupported_data_type",
         "index_vector_data",
         "index_vector_data_with_partial_params",
         "index_test_illegal_vector_params_check" };
+    private static final int TEST_SUPPORTED_DATA_TYPE_INDEX_POS = 0;
+    private static final int TEST_UNSUPPORTED_DATA_TYPE_INDEX_POS = 1;
+    private static final int TEST_VECTOR_DATA_INDEX_POS = 2;
+    private static final int TEST_VECTOR_DATA_WITH_PARTIAL_PARAMS_INDEX_POS = 3;
+    private static final int TEST_ILLEGAL_VECTOR_PARAMS_CHECK_INDEX_POS = 4;
 
     @AfterClass
     public static void cleanIndices() {
         try {
-            for (String index : BasicITIndices) {
+            for (String index : MappingITIndices) {
                 if (highLevelClient().indices().exists(new GetIndexRequest(index), RequestOptions.DEFAULT)) {
                     highLevelClient().indices().delete(new DeleteIndexRequest(index), RequestOptions.DEFAULT);
                     logger.info("clean index {}", index);
@@ -70,7 +75,7 @@ public class MappingIT extends AbstractHavenaskRestTestCase {
 
     // test supported data type
     public void testSupportedDataType() throws Exception {
-        String index = "index_supported_data_type";
+        String index = MappingITIndices[TEST_SUPPORTED_DATA_TYPE_INDEX_POS];
         // create index
         assertTrue(
             highLevelClient().indices()
@@ -134,7 +139,7 @@ public class MappingIT extends AbstractHavenaskRestTestCase {
 
     // test unsupported data type
     public void testUnsupportedDataType() throws Exception {
-        String index = "index_unsupported_data_type";
+        String index = MappingITIndices[TEST_UNSUPPORTED_DATA_TYPE_INDEX_POS];
 
         ArrayList<String> unsupportedDataType = new ArrayList<String>(
             Arrays.asList(
@@ -195,7 +200,7 @@ public class MappingIT extends AbstractHavenaskRestTestCase {
     public void testVectorData() throws Exception {
         final int TYPE_POS = 0;
 
-        String index = "index_vector_data";
+        String index = MappingITIndices[TEST_VECTOR_DATA_INDEX_POS];
         String fieldName = "image";
         int vectorDims = 2;
         String similarity = "L2_NORM";
@@ -376,7 +381,7 @@ public class MappingIT extends AbstractHavenaskRestTestCase {
     @SuppressWarnings("unchecked")
     public void testVectorDataWithPartialParams() throws Exception {
         final int TYPE_POS = 0;
-        String index = "index_vector_data_with_partial_params";
+        String index = MappingITIndices[TEST_VECTOR_DATA_WITH_PARTIAL_PARAMS_INDEX_POS];
         String fieldName = "image";
         int vectorDims = 2;
         String similarity = "L2_NORM";
@@ -513,7 +518,7 @@ public class MappingIT extends AbstractHavenaskRestTestCase {
     }
 
     public void testIllegalVectorParamsCheck() throws Exception {
-        String index = "index_test_illegal_vector_params_check";
+        String index = MappingITIndices[TEST_ILLEGAL_VECTOR_PARAMS_CHECK_INDEX_POS];
         String fieldName = "image";
         int vectorDims = 2;
         String similarity = "DOT_PRODUCT";

--- a/elastic-fed/modules/havenask-engine/src/javaRestTest/java/org/havenask/engine/RecoveryIT.java
+++ b/elastic-fed/modules/havenask-engine/src/javaRestTest/java/org/havenask/engine/RecoveryIT.java
@@ -145,8 +145,15 @@ public class RecoveryIT extends AbstractHavenaskRestTestCase {
         }, 2, TimeUnit.MINUTES);
 
         // check recovery result
-        SqlResponse recoveryResponse = highLevelClient().havenask().sql(new SqlRequest("select * from " + index), RequestOptions.DEFAULT);
-        assertEquals(testDocCount, recoveryResponse.getRowCount());
+        assertBusy(() -> {
+            SqlResponse recoveryResponse = highLevelClient().havenask()
+                .sql(new SqlRequest("select * from " + index), RequestOptions.DEFAULT);
+            assertEquals(
+                "expected doc count : " + testDocCount + ", but get : " + recoveryResponse.getRowCount(),
+                testDocCount,
+                recoveryResponse.getRowCount()
+            );
+        }, 10, TimeUnit.SECONDS);
     }
 
     @AfterClass

--- a/elastic-fed/modules/havenask-engine/src/javaRestTest/java/org/havenask/engine/SearchIT.java
+++ b/elastic-fed/modules/havenask-engine/src/javaRestTest/java/org/havenask/engine/SearchIT.java
@@ -210,11 +210,11 @@ public class SearchIT extends AbstractHavenaskRestTestCase {
         float[][] field0Values = { { 1f, 1f }, { 2f, 2f }, { 3f, 3f }, { 4f, 4f } };
         float[][] field1Values = { { 0.6f, 0.8f }, { 0.8f, 0.6f }, { 1.0f, 0.0f }, { 0.0f, 1.0f } };
 
-        String[] resSourceAsString = {
-            "{\"field1\":[1.0,1.0],\"field2\":[0.6,0.8]}",
-            "{\"field1\":[2.0,2.0],\"field2\":[0.8,0.6]}",
-            "{\"field1\":[4.0,4.0],\"field2\":[0.0,1.0]}",
-            "{\"field1\":[3.0,3.0],\"field2\":[1.0,0.0]}", };
+        String[][] resSourceAsString = {
+            { "\"field1\":[1.0,1.0]", "\"field2\":[0.6,0.8]" },
+            { "\"field1\":[2.0,2.0]", "\"field2\":[0.8,0.6]" },
+            { "\"field1\":[4.0,4.0]", "\"field2\":[0.0,1.0]" },
+            { "\"field1\":[3.0,3.0]", "\"field2\":[1.0,0.0]" } };
 
         String[] expectedId = { "1", "2", "4", "3" };
         float[] expectedScores = { 2f, 1.3133334f, 0.95263153f, 0.9111111f };
@@ -272,7 +272,10 @@ public class SearchIT extends AbstractHavenaskRestTestCase {
 
         for (int i = 0; i < dataNum; i++) {
             assertEquals(expectedId[i], searchResponse.getHits().getHits()[i].getId());
-            assertEquals(resSourceAsString[i], searchResponse.getHits().getHits()[i].getSourceAsString());
+            assertTrue(
+                searchResponse.getHits().getHits()[i].getSourceAsString().contains(resSourceAsString[i][0])
+                    && searchResponse.getHits().getHits()[i].getSourceAsString().contains(resSourceAsString[i][1])
+            );
             assertEquals(expectedScores[i], searchResponse.getHits().getHits()[i].getScore(), delta);
         }
 

--- a/elastic-fed/modules/havenask-engine/src/javaRestTest/java/org/havenask/engine/SearchIT.java
+++ b/elastic-fed/modules/havenask-engine/src/javaRestTest/java/org/havenask/engine/SearchIT.java
@@ -47,6 +47,9 @@ public class SearchIT extends AbstractHavenaskRestTestCase {
     // static logger
     private static final Logger logger = LogManager.getLogger(SearchIT.class);
     private static final String[] SearchITIndices = { "single_shard_test", "multi_shard_test", "multi_vector_test" };
+    private static final int TEST_SINGLE_SHARD_KNN_INDEX_POS = 0;
+    private static final int TEST_MULTI_SHARD_KNN_INDEX_POS = 1;
+    private static final int TEST_MULTI_KNN_QUERY_INDEX_POS = 2;
 
     @AfterClass
     public static void cleanIndices() {
@@ -63,7 +66,7 @@ public class SearchIT extends AbstractHavenaskRestTestCase {
     }
 
     public void testSingleShardKnn() throws Exception {
-        String index = "single_shard_test";
+        String index = SearchITIndices[TEST_SINGLE_SHARD_KNN_INDEX_POS];
         String fieldName = "image";
         String similarity = "l2_norm";
         int vectorDims = 2;
@@ -132,7 +135,7 @@ public class SearchIT extends AbstractHavenaskRestTestCase {
     }
 
     public void testMultiShardKnn() throws Exception {
-        String index = "multi_shard_test";
+        String index = SearchITIndices[TEST_MULTI_SHARD_KNN_INDEX_POS];
         String fieldName = "image";
         String similarity = "l2_norm";
         int vectorDims = 2;
@@ -221,7 +224,7 @@ public class SearchIT extends AbstractHavenaskRestTestCase {
     }
 
     public void testMultiKnnQuery() throws Exception {
-        String index = "multi_vector_test";
+        String index = SearchITIndices[TEST_MULTI_KNN_QUERY_INDEX_POS];
         String[] fieldNames = { "field1", "field2" };
         int[] multiVectorDims = { 2, 2 };
         String[] similarities = { "l2_norm", "dot_product" };


### PR DESCRIPTION
将一些内容封装成方法
增加cleanIndices()方法, 用于清理测试失败后的索引
修复了一些更新后DocIT存在的问题
fix#307
