### PR TITLE
写入数据时偶尔出现table未ready，写入重试增加该错误类型的判断

### DIFF
--- a/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/index/engine/HavenaskEngine.java
+++ b/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/index/engine/HavenaskEngine.java
@@ -14,30 +14,9 @@
 
 package org.havenask.engine.index.engine;
 
-import java.io.Closeable;
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.charset.StandardCharsets;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.function.BiFunction;
-import java.util.function.Function;
-import java.util.function.LongConsumer;
-import java.util.function.LongSupplier;
-
-import javax.management.MBeanTrustPermission;
-
 import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.JSONArray;
 import com.alibaba.fastjson.JSONObject;
-
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.DescribeTopicsResult;
 import org.apache.kafka.clients.admin.KafkaAdminClient;
@@ -101,6 +80,25 @@ import org.havenask.index.translog.TranslogDeletionPolicy;
 import org.havenask.search.DefaultSearchContext;
 import org.havenask.search.internal.ContextIndexSearcher;
 import suez.service.proto.ErrorCode;
+
+import javax.management.MBeanTrustPermission;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.LongConsumer;
+import java.util.function.LongSupplier;
 
 import static org.havenask.engine.search.rest.RestHavenaskSqlAction.SQL_DATABASE;
 
@@ -516,7 +514,8 @@ public class HavenaskEngine extends InternalEngine {
         if ((writeResponse.getErrorCode() == ErrorCode.TBS_ERROR_UNKOWN
             && writeResponse.getErrorMessage().contains("write response is null"))
             || (writeResponse.getErrorCode() == ErrorCode.TBS_ERROR_OTHERS
-                && writeResponse.getErrorMessage().contains("doc queue is full"))) {
+                && (writeResponse.getErrorMessage().contains("doc queue is full")
+                    || writeResponse.getErrorMessage().contains("no valid table/range")))) {
             return true;
         } else {
             return false;


### PR DESCRIPTION
失败的示例如下：
```
  2> REPRODUCE WITH: ./gradlew ':modules:havenask-engine:javaRestTest' --tests "org.havenask.engine.BasicIT.testCreateAndDeleteSameIndex" -Dtests.seed=1E20C03E619D2D5A -Dtests.security.manager=true -Dtests.jvm.argline="-XX:TieredStopAtLevel=1" -Dtests.locale=sq -Dtests.timezone=Israel -Druntime.java=11
  2> HavenaskStatusException[Havenask exception [type=i_o_exception, reason=havenask index exception, error code: TBS_ERROR_OTHERS, error message:no valid table/range for WriteRequest table: create_and_delete_same_index_test hashid: 25383]]
        at __randomizedtesting.SeedInfo.seed([1E20C03E619D2D5A:DFEB312DE1DAC51B]:0)
        at org.havenask.rest.BytesRestResponse.errorFromXContent(BytesRestResponse.java:207)
        at org.havenask.client.RestHighLevelClient.parseEntity(RestHighLevelClient.java:1680)
        at org.havenask.client.RestHighLevelClient.parseResponseException(RestHighLevelClient.java:1657)
        at org.havenask.client.RestHighLevelClient.internalPerformRequest(RestHighLevelClient.java:1414)
        at org.havenask.client.RestHighLevelClient.performRequest(RestHighLevelClient.java:1371)
        at org.havenask.client.RestHighLevelClient.performRequestAndParseEntity(RestHighLevelClient.java:1341)
        at org.havenask.client.RestHighLevelClient.index(RestHighLevelClient.java:802)
        at org.havenask.engine.BasicIT.testCreateAndDeleteSameIndex(BasicIT.java:219)
```
 fixed https://github.com/alibaba/havenask-federation/issues/314