### PR TITLE
修复havenask config配置schema异常问题

### DIFF
--- a/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/index/HavenaskIndexEventListener.java
+++ b/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/index/HavenaskIndexEventListener.java
@@ -41,7 +41,7 @@ public class HavenaskIndexEventListener implements IndexEventListener {
     }
 
     @Override
-    public void afterIndexCreated(IndexService indexService) {
+    public void afterIndexMappingUpdate(IndexService indexService) {
         String tableName = indexService.index().getName();
         ReentrantLock indexLock = metaDataSyncer.getIndexLock(tableName);
         try {


### PR DESCRIPTION
afterIndexCreated调用时，mapping还没ready，导致config生成的schema异常，改成afterIndexMappingUpdate后，可以正常生成schema