### PR TITLE
修复testCleanVersionPublishFiles偶尔失败的case

### DIFF
--- a/elastic-fed/modules/havenask-engine/src/test/java/org/havenask/engine/util/UtilsTests.java
+++ b/elastic-fed/modules/havenask-engine/src/test/java/org/havenask/engine/util/UtilsTests.java
@@ -28,9 +28,6 @@
 
 package org.havenask.engine.util;
 
-import org.havenask.common.collect.Tuple;
-import org.havenask.test.HavenaskTestCase;
-
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -38,6 +35,11 @@ import java.nio.file.Path;
 import java.util.Locale;
 import java.util.stream.Stream;
 
+import org.apache.lucene.util.LuceneTestCase;
+import org.havenask.common.collect.Tuple;
+import org.havenask.test.HavenaskTestCase;
+
+@LuceneTestCase.SuppressFileSystems("ExtrasFS")
 public class UtilsTests extends HavenaskTestCase {
     private final Path configPath;
     private final String prefix = "0000000000000000ffffffffffffffff0100000000000000";


### PR DESCRIPTION
fix https://github.com/alibaba/havenask-federation/issues/395
增加@LuceneTestCase.SuppressFileSystems("ExtrasFS")注入，防止测试case可能生成临时文件影响测试结果。