### PR TITLE
修复search接口查询不到Object对象的子fieldname的问题

### DIFF
--- a/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/index/engine/HavenaskEngine.java
+++ b/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/index/engine/HavenaskEngine.java
@@ -382,13 +382,13 @@ public class HavenaskEngine extends InternalEngine {
         ParseContext.Document rootDoc = parsedDocument.rootDoc();
         for (IndexableField field : rootDoc.getFields()) {
             String fieldName = field.name();
-            if (haDoc.containsKey(fieldName)) {
-                continue;
-            }
-
             // multi field index
             if (fieldName.contains(".")) {
                 fieldName = Schema.encodeFieldWithDot(fieldName);
+            }
+
+            if (haDoc.containsKey(fieldName)) {
+                continue;
             }
 
             // for string or number

--- a/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/index/engine/HavenaskEngine.java
+++ b/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/index/engine/HavenaskEngine.java
@@ -75,6 +75,7 @@ import org.havenask.common.xcontent.XContentHelper;
 import org.havenask.engine.HavenaskEngineEnvironment;
 import org.havenask.engine.MetaDataSyncer;
 import org.havenask.engine.NativeProcessControlService;
+import org.havenask.engine.index.config.Schema;
 import org.havenask.engine.index.mapper.VectorField;
 import org.havenask.engine.rpc.ArpcResponse;
 import org.havenask.engine.rpc.QueryTableRequest;
@@ -381,8 +382,13 @@ public class HavenaskEngine extends InternalEngine {
         ParseContext.Document rootDoc = parsedDocument.rootDoc();
         for (IndexableField field : rootDoc.getFields()) {
             String fieldName = field.name();
-            if (haDoc.containsKey(fieldName) || fieldName.contains(".")) {
+            if (haDoc.containsKey(fieldName)) {
                 continue;
+            }
+
+            // multi field index
+            if (fieldName.contains(".")) {
+                fieldName = Schema.encodeFieldWithDot(fieldName);
             }
 
             // for string or number
@@ -392,7 +398,7 @@ public class HavenaskEngine extends InternalEngine {
             }
 
             if (Objects.nonNull(stringVal)) {
-                haDoc.put(field.name(), stringVal);
+                haDoc.put(fieldName, stringVal);
                 continue;
             }
 
@@ -400,12 +406,12 @@ public class HavenaskEngine extends InternalEngine {
             if (binaryVal == null) {
                 throw new IOException("invalid field value!");
             }
-            if (field.name().equals(IdFieldMapper.NAME)) {
-                haDoc.put(field.name(), Uid.decodeId(binaryVal.bytes));
-            } else if (field.name().equals(SourceFieldMapper.NAME)) {
+            if (fieldName.equals(IdFieldMapper.NAME)) {
+                haDoc.put(fieldName, Uid.decodeId(binaryVal.bytes));
+            } else if (fieldName.equals(SourceFieldMapper.NAME)) {
                 BytesReference bytes = new BytesArray(binaryVal);
                 String src = XContentHelper.convertToJson(bytes, false, parsedDocument.getXContentType());
-                haDoc.put(field.name(), src);
+                haDoc.put(fieldName, src);
             } else if (field instanceof VectorField) {
                 VectorField vectorField = (VectorField) field;
                 float[] array = (float[]) VectorField.readValue(vectorField.binaryValue().bytes);
@@ -418,9 +424,9 @@ public class HavenaskEngine extends InternalEngine {
                     }
                     b.append(",");
                 }
-                haDoc.put(field.name(), b.toString());
+                haDoc.put(fieldName, b.toString());
             } else { // TODO other special fields support.
-                haDoc.put(field.name(), binaryVal.utf8ToString());
+                haDoc.put(fieldName, binaryVal.utf8ToString());
             }
         }
 

--- a/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/index/mapper/DenseVectorFieldMapper.java
+++ b/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/index/mapper/DenseVectorFieldMapper.java
@@ -112,7 +112,7 @@ public class DenseVectorFieldMapper extends ParametrizedFieldMapper {
         @Override
         public DenseVectorFieldMapper build(BuilderContext context) {
             DenseVectorFieldType fieldType = new DenseVectorFieldType(
-                name,
+                buildFullName(context),
                 meta.getValue(),
                 dimension.get(),
                 Similarity.fromString(similarity.get()),

--- a/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/search/HavenaskSearchQueryProcessor.java
+++ b/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/search/HavenaskSearchQueryProcessor.java
@@ -179,7 +179,8 @@ public class HavenaskSearchQueryProcessor {
     @SuppressWarnings("unchecked")
     private String getSimilarity(String fieldName, Map<String, Object> indexMapping) {
         // TODO: 需要考虑如何优化,
-        // 1.similarity的获取方式，
+        // 1.similarity的获取方式
+        // 2.需要用户使用'_'来分割Object对象的子字段
         String[] fields = fieldName.split("_");
 
         Map<String, Object> curMap = indexMapping;
@@ -197,8 +198,10 @@ public class HavenaskSearchQueryProcessor {
                 return null;
             }
         }
-        if (curMap.get("type") == VECTOR_TYPE) {
-            return curMap.get(SIMILARITY) != null ? (String) curMap.get(SIMILARITY) : VECTOR_SIMILARITY_TYPE_L2_NORM;
+        if (curMap.get("type").equals(VECTOR_TYPE)) {
+            return curMap.get(SIMILARITY) != null
+                ? ((String) curMap.get(SIMILARITY)).toUpperCase(Locale.ROOT)
+                : VECTOR_SIMILARITY_TYPE_L2_NORM;
         }
         return null;
     }

--- a/elastic-fed/modules/havenask-engine/src/test/java/org/havenask/engine/index/mapper/DenseVectorFieldMapperTests.java
+++ b/elastic-fed/modules/havenask-engine/src/test/java/org/havenask/engine/index/mapper/DenseVectorFieldMapperTests.java
@@ -19,7 +19,9 @@ import org.havenask.common.settings.Settings;
 import org.havenask.common.xcontent.XContentBuilder;
 import org.havenask.engine.HavenaskEnginePlugin;
 import org.havenask.engine.index.mapper.DenseVectorFieldMapper.DenseVectorFieldType;
+import org.havenask.index.mapper.ContentPath;
 import org.havenask.index.mapper.DocumentMapper;
+import org.havenask.index.mapper.Mapper;
 import org.havenask.index.mapper.MapperParsingException;
 import org.havenask.index.mapper.MapperService;
 import org.havenask.index.mapper.MapperTestCase;
@@ -204,5 +206,18 @@ public class DenseVectorFieldMapperTests extends MapperTestCase {
         float[] vector = new float[] { 1.0f, -2.0f };
         MapperParsingException e = expectThrows(MapperParsingException.class, () -> mapper.parse(source(b -> b.array("field", vector))));
         assertEquals("The [dot_product] similarity can only be used with unit-length vectors.", e.getCause().getMessage());
+    }
+
+    public void testBuildDenseVectorFieldMapper() throws Exception {
+        String name = "image";
+        ContentPath contentPath = new ContentPath(1);
+        contentPath.add("_doc");
+        contentPath.add("user");
+        Mapper.BuilderContext context = new Mapper.BuilderContext(Settings.EMPTY, contentPath);
+
+        DenseVectorFieldMapper.Builder builder = new DenseVectorFieldMapper.Builder(name);
+        DenseVectorFieldMapper denseVectorFieldMapper = builder.build(context);
+
+        assertEquals("user.image", denseVectorFieldMapper.name());
     }
 }


### PR DESCRIPTION
fix:https://github.com/alibaba/havenask-federation/issues/402
目前查询需要使用'_'而不是es的'.'来分隔Object对象的子fieldname