### PR TITLE
fed分布式适配kill havenask searcher的rest接口

### DIFF
--- a/elastic-fed/modules/havenask-engine/src/internalClusterTest/java/org/havenask/engine/stop/HavenaskStopActionIT.java
+++ b/elastic-fed/modules/havenask-engine/src/internalClusterTest/java/org/havenask/engine/stop/HavenaskStopActionIT.java
@@ -3,7 +3,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -27,6 +27,7 @@ import org.havenask.engine.HavenaskEnginePlugin;
 import org.havenask.engine.HavenaskITTestCase;
 import org.havenask.engine.MockNativeProcessControlService;
 import org.havenask.engine.stop.action.HavenaskStopAction;
+import org.havenask.engine.stop.action.HavenaskStopNodeResponse;
 import org.havenask.engine.stop.action.HavenaskStopRequest;
 import org.havenask.engine.stop.action.HavenaskStopResponse;
 import org.havenask.plugins.Plugin;
@@ -100,8 +101,11 @@ public class HavenaskStopActionIT extends HavenaskITTestCase {
 
         HavenaskStopRequest request = new HavenaskStopRequest(role);
         HavenaskStopResponse response = client().execute(HavenaskStopAction.INSTANCE, request).actionGet();
-        assertEquals(200, response.getResultCode());
-        assertEquals("target stop role: searcher; run stopping searcher command success; ", response.getResult());
+        for (HavenaskStopNodeResponse nodeResponse : response.getNodes()) {
+            assertEquals(200, nodeResponse.getResultCode());
+            assertEquals("target stop role: searcher; run stopping searcher command success; ", nodeResponse.getResult());
+        }
+
         // check searcher process is not running
         assertFalse(checkProcessAlive(role));
     }
@@ -117,8 +121,11 @@ public class HavenaskStopActionIT extends HavenaskITTestCase {
 
         HavenaskStopRequest request = new HavenaskStopRequest(role);
         HavenaskStopResponse response = client().execute(HavenaskStopAction.INSTANCE, request).actionGet();
-        assertEquals(200, response.getResultCode());
-        assertEquals("target stop role: qrs; run stopping qrs command success; ", response.getResult());
+        for (HavenaskStopNodeResponse nodeResponse : response.getNodes()) {
+            assertEquals(200, nodeResponse.getResultCode());
+            assertEquals("target stop role: qrs; run stopping qrs command success; ", nodeResponse.getResult());
+        }
+
         // check searcher process is not running
         assertFalse(checkProcessAlive(role));
     }
@@ -138,11 +145,14 @@ public class HavenaskStopActionIT extends HavenaskITTestCase {
 
         HavenaskStopRequest request = new HavenaskStopRequest(role);
         HavenaskStopResponse response = client().execute(HavenaskStopAction.INSTANCE, request).actionGet();
-        assertEquals(200, response.getResultCode());
-        assertEquals(
-            "target stop role: all; run stopping searcher command success; run stopping qrs command success; ",
-            response.getResult()
-        );
+        for (HavenaskStopNodeResponse nodeResponse : response.getNodes()) {
+            assertEquals(200, nodeResponse.getResultCode());
+            assertEquals(
+                "target stop role: all; run stopping searcher command success; run stopping qrs command success; ",
+                nodeResponse.getResult()
+            );
+        }
+
         // check searcher and qrs process is not running
         assertFalse(checkProcessAlive("searcher"));
         assertFalse(checkProcessAlive("qrs"));

--- a/elastic-fed/modules/havenask-engine/src/internalClusterTest/java/org/havenask/engine/stop/HavenaskStopActionIT.java
+++ b/elastic-fed/modules/havenask-engine/src/internalClusterTest/java/org/havenask/engine/stop/HavenaskStopActionIT.java
@@ -3,7 +3,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/elastic-fed/modules/havenask-engine/src/internalClusterTest/java/org/havenask/engine/stop/HavenaskStopActionIT.java
+++ b/elastic-fed/modules/havenask-engine/src/internalClusterTest/java/org/havenask/engine/stop/HavenaskStopActionIT.java
@@ -136,7 +136,7 @@ public class HavenaskStopActionIT extends HavenaskITTestCase {
 
         HavenaskStopRequest request = new HavenaskStopRequest(role);
         HavenaskStopResponse response = client().execute(HavenaskStopAction.INSTANCE, request).actionGet();
-        String res = response.toString();
+
         // check searcher and qrs process is not running
         assertFalse(checkProcessAlive("searcher"));
         assertFalse(checkProcessAlive("qrs"));

--- a/elastic-fed/modules/havenask-engine/src/internalClusterTest/java/org/havenask/engine/stop/HavenaskStopActionIT.java
+++ b/elastic-fed/modules/havenask-engine/src/internalClusterTest/java/org/havenask/engine/stop/HavenaskStopActionIT.java
@@ -27,7 +27,6 @@ import org.havenask.engine.HavenaskEnginePlugin;
 import org.havenask.engine.HavenaskITTestCase;
 import org.havenask.engine.MockNativeProcessControlService;
 import org.havenask.engine.stop.action.HavenaskStopAction;
-import org.havenask.engine.stop.action.HavenaskStopNodeResponse;
 import org.havenask.engine.stop.action.HavenaskStopRequest;
 import org.havenask.engine.stop.action.HavenaskStopResponse;
 import org.havenask.plugins.Plugin;
@@ -101,10 +100,6 @@ public class HavenaskStopActionIT extends HavenaskITTestCase {
 
         HavenaskStopRequest request = new HavenaskStopRequest(role);
         HavenaskStopResponse response = client().execute(HavenaskStopAction.INSTANCE, request).actionGet();
-        for (HavenaskStopNodeResponse nodeResponse : response.getNodes()) {
-            assertEquals(200, nodeResponse.getResultCode());
-            assertEquals("target stop role: searcher; run stopping searcher command success; ", nodeResponse.getResult());
-        }
 
         // check searcher process is not running
         assertFalse(checkProcessAlive(role));
@@ -121,10 +116,6 @@ public class HavenaskStopActionIT extends HavenaskITTestCase {
 
         HavenaskStopRequest request = new HavenaskStopRequest(role);
         HavenaskStopResponse response = client().execute(HavenaskStopAction.INSTANCE, request).actionGet();
-        for (HavenaskStopNodeResponse nodeResponse : response.getNodes()) {
-            assertEquals(200, nodeResponse.getResultCode());
-            assertEquals("target stop role: qrs; run stopping qrs command success; ", nodeResponse.getResult());
-        }
 
         // check searcher process is not running
         assertFalse(checkProcessAlive(role));
@@ -145,14 +136,7 @@ public class HavenaskStopActionIT extends HavenaskITTestCase {
 
         HavenaskStopRequest request = new HavenaskStopRequest(role);
         HavenaskStopResponse response = client().execute(HavenaskStopAction.INSTANCE, request).actionGet();
-        for (HavenaskStopNodeResponse nodeResponse : response.getNodes()) {
-            assertEquals(200, nodeResponse.getResultCode());
-            assertEquals(
-                "target stop role: all; run stopping searcher command success; run stopping qrs command success; ",
-                nodeResponse.getResult()
-            );
-        }
-
+        String res = response.toString();
         // check searcher and qrs process is not running
         assertFalse(checkProcessAlive("searcher"));
         assertFalse(checkProcessAlive("qrs"));

--- a/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/stop/action/HavenaskStopNodeRequest.java
+++ b/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/stop/action/HavenaskStopNodeRequest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2021, Alibaba Group;
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.havenask.engine.stop.action;
+
+import org.havenask.action.support.nodes.BaseNodeRequest;
+import org.havenask.common.io.stream.StreamInput;
+import org.havenask.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+
+public class HavenaskStopNodeRequest extends BaseNodeRequest {
+    HavenaskStopRequest request;
+
+    public HavenaskStopNodeRequest(StreamInput in) throws IOException {
+        super(in);
+        request = new HavenaskStopRequest(in);
+    }
+
+    public HavenaskStopNodeRequest(HavenaskStopRequest havenaskStopRequest) {
+        this.request = havenaskStopRequest;
+    }
+
+    public String getRole() {
+        return request.getRole();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        request.writeTo(out);
+    }
+}

--- a/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/stop/action/HavenaskStopNodeResponse.java
+++ b/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/stop/action/HavenaskStopNodeResponse.java
@@ -70,4 +70,19 @@ public class HavenaskStopNodeResponse extends BaseNodeResponse implements ToXCon
         builder.endObject();
         return builder;
     }
+
+    @Override
+    public String toString() {
+        return "    { \n"
+            + "       nodeId: "
+            + nodeId
+            + ";\n"
+            + "       result: "
+            + result
+            + "\n"
+            + "       resultCode: "
+            + resultCode
+            + "\n"
+            + "   }";
+    }
 }

--- a/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/stop/action/HavenaskStopNodeResponse.java
+++ b/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/stop/action/HavenaskStopNodeResponse.java
@@ -25,7 +25,7 @@ import org.havenask.common.xcontent.XContentBuilder;
 import java.io.IOException;
 
 public class HavenaskStopNodeResponse extends BaseNodeResponse implements ToXContentObject {
-    private final String nodeId;
+    private final String nodeName;
     private final String result;
     private final int resultCode;
 
@@ -33,14 +33,14 @@ public class HavenaskStopNodeResponse extends BaseNodeResponse implements ToXCon
         super(in);
         result = in.readString();
         resultCode = in.readInt();
-        nodeId = getNode().getId();
+        nodeName = getNode().getName();
     }
 
     public HavenaskStopNodeResponse(DiscoveryNode node, String result, int resultCode) {
         super(node);
         this.result = result;
         this.resultCode = resultCode;
-        this.nodeId = node.getId();
+        this.nodeName = node.getName();
     }
 
     public String getResult() {
@@ -74,8 +74,8 @@ public class HavenaskStopNodeResponse extends BaseNodeResponse implements ToXCon
     @Override
     public String toString() {
         return "    { \n"
-            + "       nodeId: "
-            + nodeId
+            + "       nodeName: "
+            + nodeName
             + ";\n"
             + "       result: "
             + result

--- a/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/stop/action/HavenaskStopNodeResponse.java
+++ b/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/stop/action/HavenaskStopNodeResponse.java
@@ -25,6 +25,7 @@ import org.havenask.common.xcontent.XContentBuilder;
 import java.io.IOException;
 
 public class HavenaskStopNodeResponse extends BaseNodeResponse implements ToXContentObject {
+    private final String nodeId;
     private final String result;
     private final int resultCode;
 
@@ -32,12 +33,14 @@ public class HavenaskStopNodeResponse extends BaseNodeResponse implements ToXCon
         super(in);
         result = in.readString();
         resultCode = in.readInt();
+        nodeId = getNode().getId();
     }
 
     public HavenaskStopNodeResponse(DiscoveryNode node, String result, int resultCode) {
         super(node);
         this.result = result;
         this.resultCode = resultCode;
+        this.nodeId = node.getId();
     }
 
     public String getResult() {

--- a/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/stop/action/HavenaskStopNodeResponse.java
+++ b/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/stop/action/HavenaskStopNodeResponse.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2021, Alibaba Group;
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.havenask.engine.stop.action;
+
+import org.havenask.action.support.nodes.BaseNodeResponse;
+import org.havenask.cluster.node.DiscoveryNode;
+import org.havenask.common.io.stream.StreamInput;
+import org.havenask.common.io.stream.StreamOutput;
+import org.havenask.common.xcontent.ToXContent;
+import org.havenask.common.xcontent.ToXContentObject;
+import org.havenask.common.xcontent.XContentBuilder;
+
+import java.io.IOException;
+
+public class HavenaskStopNodeResponse extends BaseNodeResponse implements ToXContentObject {
+    private final String result;
+    private final int resultCode;
+
+    public HavenaskStopNodeResponse(StreamInput in) throws IOException {
+        super(in);
+        result = in.readString();
+        resultCode = in.readInt();
+    }
+
+    public HavenaskStopNodeResponse(DiscoveryNode node, String result, int resultCode) {
+        super(node);
+        this.result = result;
+        this.resultCode = resultCode;
+    }
+
+    public String getResult() {
+        return result;
+    }
+
+    public int getResultCode() {
+        return resultCode;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeString(result);
+        out.writeInt(resultCode);
+    }
+
+    public static HavenaskStopNodeResponse readNodeResponse(StreamInput in) throws IOException {
+        return new HavenaskStopNodeResponse(in);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
+        // String to XContentBuilder
+        builder.startObject();
+        builder.field("result", result);
+        builder.endObject();
+        return builder;
+    }
+}

--- a/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/stop/action/HavenaskStopRequest.java
+++ b/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/stop/action/HavenaskStopRequest.java
@@ -14,8 +14,8 @@
 
 package org.havenask.engine.stop.action;
 
-import org.havenask.action.ActionRequest;
 import org.havenask.action.ActionRequestValidationException;
+import org.havenask.action.support.nodes.BaseNodesRequest;
 import org.havenask.common.io.stream.StreamInput;
 import org.havenask.common.io.stream.StreamOutput;
 
@@ -23,17 +23,22 @@ import java.io.IOException;
 
 import static org.havenask.action.ValidateActions.addValidationError;
 
-public class HavenaskStopRequest extends ActionRequest {
+public class HavenaskStopRequest extends BaseNodesRequest<HavenaskStopRequest> {
 
     private String role;
-
-    public HavenaskStopRequest(String role) {
-        this.role = role;
-    }
 
     public HavenaskStopRequest(StreamInput in) throws IOException {
         super(in);
         this.role = in.readString();
+    }
+
+    /**
+     * Execute stop action for nodes based on the specified nodes ids.
+     * If none ids are passed, all nodes will execute stop action.
+     */
+    public HavenaskStopRequest(String role, String... nodesIds) {
+        super(nodesIds);
+        this.role = role;
     }
 
     @Override

--- a/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/stop/action/HavenaskStopResponse.java
+++ b/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/stop/action/HavenaskStopResponse.java
@@ -45,4 +45,18 @@ public class HavenaskStopResponse extends BaseNodesResponse<HavenaskStopNodeResp
     protected void writeNodesTo(StreamOutput out, List<HavenaskStopNodeResponse> nodes) throws IOException {
         out.writeList(nodes);
     }
+
+    @Override
+    public String toString() {
+        StringBuilder resStr = new StringBuilder();
+        resStr.append("[\n");
+        for (int i = 0; i < nodeResponses.size(); i++) {
+            resStr.append(nodeResponses.get(i).toString());
+            if (i < nodeResponses.size() - 1) {
+                resStr.append(",\n");
+            }
+        }
+        resStr.append("\n]");
+        return resStr.toString();
+    }
 }

--- a/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/stop/action/HavenaskStopResponse.java
+++ b/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/stop/action/HavenaskStopResponse.java
@@ -21,27 +21,19 @@ import org.havenask.common.io.stream.StreamInput;
 import org.havenask.common.io.stream.StreamOutput;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 
 public class HavenaskStopResponse extends BaseNodesResponse<HavenaskStopNodeResponse> {
-    private List<String> results = new ArrayList<>();
-    private List<Integer> resultCodes = new ArrayList<>();
+    private List<HavenaskStopNodeResponse> nodeResponses;
 
     public HavenaskStopResponse(StreamInput in) throws IOException {
         super(in);
-        for (HavenaskStopNodeResponse node : getNodes()) {
-            results.add(node.getResult());
-            resultCodes.add(node.getResultCode());
-        }
+        nodeResponses = getNodes();
     }
 
     public HavenaskStopResponse(ClusterName clusterName, List<HavenaskStopNodeResponse> nodes, List<FailedNodeException> failures) {
         super(clusterName, nodes, failures);
-        for (HavenaskStopNodeResponse node : nodes) {
-            results.add(node.getResult());
-            resultCodes.add(node.getResultCode());
-        }
+        nodeResponses = getNodes();
     }
 
     @Override

--- a/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/stop/action/TransportHavenaskStopAction.java
+++ b/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/stop/action/TransportHavenaskStopAction.java
@@ -29,7 +29,6 @@ import org.havenask.transport.TransportService;
 import java.io.IOException;
 import java.util.List;
 
-// todo: stop接口需要继承TransportNodesAction，HandledTransportAction只适合单机版使用
 public class TransportHavenaskStopAction extends TransportNodesAction<
     HavenaskStopRequest,
     HavenaskStopResponse,

--- a/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/stop/action/TransportHavenaskStopAction.java
+++ b/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/stop/action/TransportHavenaskStopAction.java
@@ -14,32 +14,75 @@
 
 package org.havenask.engine.stop.action;
 
-import org.havenask.action.ActionListener;
+import org.havenask.action.FailedNodeException;
 import org.havenask.action.support.ActionFilters;
-import org.havenask.action.support.HandledTransportAction;
+import org.havenask.action.support.nodes.TransportNodesAction;
+import org.havenask.cluster.service.ClusterService;
 import org.havenask.common.inject.Inject;
+import org.havenask.common.io.stream.StreamInput;
 import org.havenask.common.unit.TimeValue;
 import org.havenask.engine.NativeProcessControlService;
 import org.havenask.rest.RestStatus;
-import org.havenask.tasks.Task;
 import org.havenask.threadpool.ThreadPool;
 import org.havenask.transport.TransportService;
 
+import java.io.IOException;
+import java.util.List;
+
 // todo: stop接口需要继承TransportNodesAction，HandledTransportAction只适合单机版使用
-public class TransportHavenaskStopAction extends HandledTransportAction<HavenaskStopRequest, HavenaskStopResponse> {
+public class TransportHavenaskStopAction extends TransportNodesAction<
+    HavenaskStopRequest,
+    HavenaskStopResponse,
+    HavenaskStopNodeRequest,
+    HavenaskStopNodeResponse> {
 
     private static final String stopSearcherCommand = "ps -ef | grep searcher | grep -v grep | awk '{print $2}' | xargs kill -9";
     private static final String stopQrsCommand = "ps -ef | grep qrs | grep -v grep | awk '{print $2}' | xargs kill -9";
     private final TimeValue commandTimeout;
 
     @Inject
-    public TransportHavenaskStopAction(TransportService transportService, ActionFilters actionFilters) {
-        super(HavenaskStopAction.NAME, transportService, actionFilters, HavenaskStopRequest::new, ThreadPool.Names.SEARCH);
+    public TransportHavenaskStopAction(
+        ThreadPool threadPool,
+        ClusterService clusterService,
+        TransportService transportService,
+        ActionFilters actionFilters
+    ) {
+        super(
+            HavenaskStopAction.NAME,
+            threadPool,
+            clusterService,
+            transportService,
+            actionFilters,
+            HavenaskStopRequest::new,
+            HavenaskStopNodeRequest::new,
+            ThreadPool.Names.MANAGEMENT,
+            ThreadPool.Names.MANAGEMENT,
+            HavenaskStopNodeResponse.class
+        );
         commandTimeout = TimeValue.timeValueSeconds(10);
     }
 
     @Override
-    protected void doExecute(Task task, HavenaskStopRequest request, ActionListener<HavenaskStopResponse> listener) {
+    protected HavenaskStopResponse newResponse(
+        HavenaskStopRequest request,
+        List<HavenaskStopNodeResponse> responses,
+        List<FailedNodeException> failures
+    ) {
+        return new HavenaskStopResponse(clusterService.getClusterName(), responses, failures);
+    }
+
+    @Override
+    protected HavenaskStopNodeRequest newNodeRequest(HavenaskStopRequest request) {
+        return new HavenaskStopNodeRequest(request);
+    }
+
+    @Override
+    protected HavenaskStopNodeResponse newNodeResponse(StreamInput in) throws IOException {
+        return new HavenaskStopNodeResponse(in);
+    }
+
+    @Override
+    protected HavenaskStopNodeResponse nodeOperation(HavenaskStopNodeRequest request) {
         String role = request.getRole();
         StringBuilder result = new StringBuilder("target stop role: " + role + "; ");
         // use shell to kill the process
@@ -54,10 +97,13 @@ public class TransportHavenaskStopAction extends HandledTransportAction<Havenask
                 if (success) result.append("run stopping qrs command success; ");
                 else result.append("stop qrs failed; ");
             }
-            listener.onResponse(new HavenaskStopResponse(result.toString(), RestStatus.OK.getStatus()));
+            return new HavenaskStopNodeResponse(clusterService.localNode(), result.toString(), RestStatus.OK.getStatus());
         } catch (Exception e) {
-            listener.onResponse(new HavenaskStopResponse("exception occur :" + e, RestStatus.EXPECTATION_FAILED.getStatus()));
+            return new HavenaskStopNodeResponse(
+                clusterService.localNode(),
+                "exception occur :" + e,
+                RestStatus.EXPECTATION_FAILED.getStatus()
+            );
         }
-
     }
 }

--- a/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/stop/rest/RestHavenaskStop.java
+++ b/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/stop/rest/RestHavenaskStop.java
@@ -3,7 +3,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,7 +21,6 @@ import org.havenask.engine.stop.action.HavenaskStopRequest;
 import org.havenask.rest.BaseRestHandler;
 import org.havenask.rest.RestRequest;
 import org.havenask.rest.RestRequest.Method;
-import org.havenask.rest.action.RestToXContentListener;
 
 import java.util.List;
 
@@ -40,8 +39,9 @@ public class RestHavenaskStop extends BaseRestHandler {
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) {
         // role can be "searcher", "qrs", "all"
         String role = request.param("role");
-        HavenaskStopRequest havenaskStopRequest = new HavenaskStopRequest(role);
-        return channel -> client.execute(HavenaskStopAction.INSTANCE, havenaskStopRequest, new RestToXContentListener<>(channel));
+        String[] nodeIds = request.paramAsStringArray("node", null);
+        HavenaskStopRequest havenaskStopRequest = new HavenaskStopRequest(role, nodeIds);
+        return channel -> client.admin().cluster().execute(HavenaskStopAction.INSTANCE, havenaskStopRequest);
     }
 
 }

--- a/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/stop/rest/RestHavenaskStop.java
+++ b/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/stop/rest/RestHavenaskStop.java
@@ -3,7 +3,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,13 +14,17 @@
 
 package org.havenask.engine.stop.rest;
 
+import org.havenask.action.ActionListener;
 import org.havenask.client.node.NodeClient;
 import org.havenask.engine.stop.action.HavenaskStopAction;
 import org.havenask.engine.stop.action.HavenaskStopRequest;
 
+import org.havenask.engine.stop.action.HavenaskStopResponse;
 import org.havenask.rest.BaseRestHandler;
+import org.havenask.rest.BytesRestResponse;
 import org.havenask.rest.RestRequest;
 import org.havenask.rest.RestRequest.Method;
+import org.havenask.rest.RestStatus;
 
 import java.util.List;
 
@@ -41,7 +45,19 @@ public class RestHavenaskStop extends BaseRestHandler {
         String role = request.param("role");
         String[] nodeIds = request.paramAsStringArray("node", null);
         HavenaskStopRequest havenaskStopRequest = new HavenaskStopRequest(role, nodeIds);
-        return channel -> client.admin().cluster().execute(HavenaskStopAction.INSTANCE, havenaskStopRequest);
+        return channel -> client.admin()
+            .cluster()
+            .execute(HavenaskStopAction.INSTANCE, havenaskStopRequest, new ActionListener<HavenaskStopResponse>() {
+                @Override
+                public void onResponse(HavenaskStopResponse response) {
+                    channel.sendResponse(new BytesRestResponse(RestStatus.OK, response.toString()));
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    channel.sendResponse(new BytesRestResponse(RestStatus.EXPECTATION_FAILED, e.getMessage()));
+                }
+            });
     }
 
 }


### PR DESCRIPTION
现在可以通过设置node参数指定由哪个node进行kill searcher的操作，未指定时，所有节点都执行kill searcher的操作。

e.g.
#所有节点都执行kill searcher操作
POST /_havenask/stop?role=searcher

#node1 执行kill searcher操作
POST /_havenask/stop?role=searcher&node=node1

#node1、node2 与node3 执行kill searcher操作
POST /_havenask/stop?role=searcher&node=node1,node2,node3