### PR TITLE
增加创建havenask索引时支持配置havenask参数的REST接口

### DIFF
--- a/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/HavenaskEnginePlugin.java
+++ b/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/HavenaskEnginePlugin.java
@@ -53,6 +53,7 @@ import org.havenask.common.settings.Settings;
 import org.havenask.common.settings.SettingsFilter;
 import org.havenask.common.unit.TimeValue;
 import org.havenask.common.xcontent.NamedXContentRegistry;
+import org.havenask.engine.create.rest.RestHavenaskCreate;
 import org.havenask.engine.index.HavenaskIndexEventListener;
 import org.havenask.engine.index.engine.EngineSettings;
 import org.havenask.engine.index.engine.HavenaskEngine;
@@ -242,6 +243,9 @@ public class HavenaskEnginePlugin extends Plugin
             EngineSettings.HAVENASK_BUILD_CONFIG_MAX_DOC_COUNT,
             EngineSettings.HAVENASK_WAL_CONFIG_SINK_QUEUE_SIZE,
             EngineSettings.HAVENASK_HASH_MODE_HASH_FIELD,
+            EngineSettings.HAVENASK_CLUSTER_JSON,
+            EngineSettings.HAVENASK_DATA_TABLE_JSON,
+            EngineSettings.HAVENASK_SCHEMA_JSON,
             NativeProcessControlService.HAVENASK_COMMAND_TIMEOUT_SETTING,
             NativeProcessControlService.HAVENASK_SEARCHER_HTTP_PORT_SETTING,
             NativeProcessControlService.HAVENASK_SEARCHER_TCP_PORT_SETTING,
@@ -272,7 +276,12 @@ public class HavenaskEnginePlugin extends Plugin
         IndexNameExpressionResolver indexNameExpressionResolver,
         Supplier<DiscoveryNodes> nodesInCluster
     ) {
-        return Arrays.asList(new RestHavenaskSqlAction(), new RestHavenaskSqlClientInfoAction(), new RestHavenaskStop());
+        return Arrays.asList(
+            new RestHavenaskSqlAction(),
+            new RestHavenaskSqlClientInfoAction(),
+            new RestHavenaskStop(),
+            new RestHavenaskCreate()
+        );
     }
 
     @Override

--- a/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/create/rest/RestHavenaskCreate.java
+++ b/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/create/rest/RestHavenaskCreate.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2021, Alibaba Group;
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.havenask.engine.create.rest;
+
+import org.havenask.action.admin.indices.create.CreateIndexRequest;
+import org.havenask.client.node.NodeClient;
+import org.havenask.common.xcontent.LoggingDeprecationHandler;
+import org.havenask.common.xcontent.XContentParser;
+import org.havenask.engine.util.JsonPrettyFormatter;
+import org.havenask.rest.BaseRestHandler;
+import org.havenask.rest.RestRequest;
+import org.havenask.rest.action.RestToXContentListener;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+public class RestHavenaskCreate extends BaseRestHandler {
+    @Override
+    public String getName() {
+        return "havenask_create_action";
+    }
+
+    public List<Route> routes() {
+        return List.of(new Route(RestRequest.Method.PUT, "/_havenask/create/{index}"));
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
+        String index = request.param("index");
+        XContentParser parser = request.contentParser();
+        Map<String, Object> source = parser.map();
+
+        Map<String, Object> clusters = (Map<String, Object>) source.remove("cluster");
+        Map<String, Object> dataTables = (Map<String, Object>) source.remove("data_table");
+        Map<String, Object> schemas = (Map<String, Object>) source.remove("schema");
+
+        Map<String, Object> settings = (Map<String, Object>) source.remove("settings");
+        if (clusters != null) {
+            settings.put("index.havenask.cluster.json", JsonPrettyFormatter.toJsonString(clusters));
+        }
+        if (dataTables != null) {
+            settings.put("index.havenask.data_table.json", JsonPrettyFormatter.toJsonString(dataTables));
+        }
+        if (schemas != null) {
+            settings.put("index.havenask.schema.json", JsonPrettyFormatter.toJsonString(schemas));
+        }
+
+        CreateIndexRequest createIndexRequest = new CreateIndexRequest(index);
+        createIndexRequest.settings(settings);
+        Map<String, Object> mappings = (Map<String, Object>) source.remove("mappings");
+        createIndexRequest.mapping("_doc", mappings);
+        createIndexRequest.source(source, LoggingDeprecationHandler.INSTANCE);
+
+        return channel -> client.admin().indices().create(createIndexRequest, new RestToXContentListener<>(channel));
+    }
+}

--- a/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/index/config/generator/BizConfigGenerator.java
+++ b/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/index/config/generator/BizConfigGenerator.java
@@ -91,56 +91,95 @@ public class BizConfigGenerator {
     }
 
     private void generateClusterConfig(String version) throws IOException {
-        BizConfig bizConfig = new BizConfig();
-        bizConfig.cluster_config.builder_rule_config.partition_count = indexSettings.getAsInt(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1);
-        bizConfig.online_index_config.build_config.max_doc_count = EngineSettings.HAVENASK_BUILD_CONFIG_MAX_DOC_COUNT.get(indexSettings);
-        bizConfig.cluster_config.cluster_name = indexName;
-        bizConfig.cluster_config.table_name = indexName;
-        bizConfig.wal_config.sink.queue_name = indexName;
-        bizConfig.wal_config.sink.queue_size = String.valueOf(EngineSettings.HAVENASK_WAL_CONFIG_SINK_QUEUE_SIZE.get(indexSettings));
-        if (EngineSettings.HAVENASK_HASH_MODE_HASH_FIELD.exists(indexSettings)) {
-            bizConfig.cluster_config.hash_mode.hash_field = EngineSettings.HAVENASK_HASH_MODE_HASH_FIELD.get(indexSettings);
-        }
+        String clusterJson = EngineSettings.HAVENASK_CLUSTER_JSON.get(indexSettings);
         Path clusterConfigPath = configPath.resolve(version).resolve(CLUSTER_DIR).resolve(indexName + CLUSTER_FILE_SUFFIX);
-        Files.write(
-            clusterConfigPath,
-            bizConfig.toString().getBytes(StandardCharsets.UTF_8),
-            StandardOpenOption.CREATE,
-            StandardOpenOption.TRUNCATE_EXISTING
-        );
+
+        if (clusterJson != "") {
+            Files.write(
+                clusterConfigPath,
+                clusterJson.getBytes(StandardCharsets.UTF_8),
+                StandardOpenOption.CREATE,
+                StandardOpenOption.TRUNCATE_EXISTING
+            );
+        } else {
+            BizConfig bizConfig = new BizConfig();
+            bizConfig.cluster_config.builder_rule_config.partition_count = indexSettings.getAsInt(
+                IndexMetadata.SETTING_NUMBER_OF_SHARDS,
+                1
+            );
+            bizConfig.online_index_config.build_config.max_doc_count = EngineSettings.HAVENASK_BUILD_CONFIG_MAX_DOC_COUNT.get(
+                indexSettings
+            );
+            bizConfig.cluster_config.cluster_name = indexName;
+            bizConfig.cluster_config.table_name = indexName;
+            bizConfig.wal_config.sink.queue_name = indexName;
+            bizConfig.wal_config.sink.queue_size = String.valueOf(EngineSettings.HAVENASK_WAL_CONFIG_SINK_QUEUE_SIZE.get(indexSettings));
+            if (EngineSettings.HAVENASK_HASH_MODE_HASH_FIELD.exists(indexSettings)) {
+                bizConfig.cluster_config.hash_mode.hash_field = EngineSettings.HAVENASK_HASH_MODE_HASH_FIELD.get(indexSettings);
+            }
+
+            Files.write(
+                clusterConfigPath,
+                bizConfig.toString().getBytes(StandardCharsets.UTF_8),
+                StandardOpenOption.CREATE,
+                StandardOpenOption.TRUNCATE_EXISTING
+            );
+        }
     }
 
     private Schema generateSchema(String version) throws IOException {
         SchemaGenerator schemaGenerator = new SchemaGenerator();
         Schema schema = schemaGenerator.getSchema(indexName, indexSettings, mapperService);
         Path schemaPath = configPath.resolve(version).resolve(SCHEMAS_DIR).resolve(indexName + SCHEMAS_FILE_SUFFIX);
-        Files.write(
-            schemaPath,
-            schema.toString().getBytes(StandardCharsets.UTF_8),
-            StandardOpenOption.CREATE,
-            StandardOpenOption.TRUNCATE_EXISTING
-        );
+
+        String schemaJson = EngineSettings.HAVENASK_SCHEMA_JSON.get(indexSettings);
+        if (schemaJson != "") {
+            Files.write(
+                schemaPath,
+                schemaJson.getBytes(StandardCharsets.UTF_8),
+                StandardOpenOption.CREATE,
+                StandardOpenOption.TRUNCATE_EXISTING
+            );
+        } else {
+            Files.write(
+                schemaPath,
+                schema.toString().getBytes(StandardCharsets.UTF_8),
+                StandardOpenOption.CREATE,
+                StandardOpenOption.TRUNCATE_EXISTING
+            );
+        }
         return schema;
     }
 
     private void generateDataTable(Schema schema, String version) throws IOException {
-        DataTable dataTable = new DataTable();
-        ProcessorChainConfig processorChainConfig = new ProcessorChainConfig();
-        processorChainConfig.clusters = List.of(indexName);
-        if (schema != null && schema.getDupFields().size() > 0) {
-            ProcessChain processChain = new ProcessChain();
-            processChain.class_name = "DupFieldProcessor";
-            processChain.parameters = new HashMap<>();
-            schema.getDupFields().forEach((field) -> { processChain.parameters.put(SchemaGenerator.DUP_PREFIX + field, field); });
-            processorChainConfig.document_processor_chain.add(processChain);
-        }
-        dataTable.processor_chain_config = List.of(processorChainConfig);
+        String dataTableJson = EngineSettings.HAVENASK_DATA_TABLE_JSON.get(indexSettings);
         Path dataTablePath = configPath.resolve(version).resolve(DATA_TABLES_DIR).resolve(indexName + DATA_TABLES_FILE_SUFFIX);
-        Files.write(
-            dataTablePath,
-            dataTable.toString().getBytes(StandardCharsets.UTF_8),
-            StandardOpenOption.CREATE,
-            StandardOpenOption.TRUNCATE_EXISTING
-        );
+        if (dataTableJson != "") {
+            Files.write(
+                dataTablePath,
+                dataTableJson.getBytes(StandardCharsets.UTF_8),
+                StandardOpenOption.CREATE,
+                StandardOpenOption.TRUNCATE_EXISTING
+            );
+        } else {
+            DataTable dataTable = new DataTable();
+            ProcessorChainConfig processorChainConfig = new ProcessorChainConfig();
+            processorChainConfig.clusters = List.of(indexName);
+            if (schema != null && schema.getDupFields().size() > 0) {
+                ProcessChain processChain = new ProcessChain();
+                processChain.class_name = "DupFieldProcessor";
+                processChain.parameters = new HashMap<>();
+                schema.getDupFields().forEach((field) -> { processChain.parameters.put(SchemaGenerator.DUP_PREFIX + field, field); });
+                processorChainConfig.document_processor_chain.add(processChain);
+            }
+            dataTable.processor_chain_config = List.of(processorChainConfig);
+
+            Files.write(
+                dataTablePath,
+                dataTable.toString().getBytes(StandardCharsets.UTF_8),
+                StandardOpenOption.CREATE,
+                StandardOpenOption.TRUNCATE_EXISTING
+            );
+        }
     }
 }

--- a/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/index/engine/EngineSettings.java
+++ b/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/index/engine/EngineSettings.java
@@ -145,6 +145,30 @@ public class EngineSettings {
         Property.Final
     );
 
+    public static final Setting<String> HAVENASK_CLUSTER_JSON = new Setting<>(
+        "index.havenask.cluster.json",
+        "",
+        (s) -> s,
+        Setting.Property.IndexScope,
+        Property.Final
+    );
+
+    public static final Setting<String> HAVENASK_DATA_TABLE_JSON = new Setting<>(
+        "index.havenask.data_table.json",
+        "",
+        (s) -> s,
+        Setting.Property.IndexScope,
+        Property.Final
+    );
+
+    public static final Setting<String> HAVENASK_SCHEMA_JSON = new Setting<>(
+        "index.havenask.schema.json",
+        "",
+        (s) -> s,
+        Setting.Property.IndexScope,
+        Property.Final
+    );
+
     public static boolean isHavenaskEngine(Settings indexSettings) {
         return ENGINE_HAVENASK.equals(ENGINE_TYPE_SETTING.get(indexSettings));
     }

--- a/elastic-fed/modules/havenask-engine/src/test/java/org/havenask/engine/index/config/generator/TableConfigGeneratorTests.java
+++ b/elastic-fed/modules/havenask-engine/src/test/java/org/havenask/engine/index/config/generator/TableConfigGeneratorTests.java
@@ -472,4 +472,148 @@ public class TableConfigGeneratorTests extends MapperServiceTestCase {
             assertEquals(expect, content);
         }
     }
+
+    public void testGenerateByHavenaskParamsSettings() throws IOException {
+        String indexName = randomAlphaOfLength(5);
+        MapperService mapperService = createMapperService(fieldMapping(b -> b.field("type", "keyword")));
+        Path configPath = createTempDir();
+        Files.createDirectories(configPath.resolve(TABLE_DIR).resolve("0").resolve(CLUSTER_DIR));
+        Files.createDirectories(configPath.resolve(TABLE_DIR).resolve("0").resolve(SCHEMAS_DIR));
+        Files.createDirectories(configPath.resolve(TABLE_DIR).resolve("0").resolve(DATA_TABLES_DIR));
+
+        String clusterJson = "{\n"
+            + "    \"build_option_config\" : {\n"
+            + "        \"async_build\" : true,\n"
+            + "        \"async_queue_size\" : 1000,\n"
+            + "        \"document_filter\" : true,\n"
+            + "        \"max_recover_time\" : 30,\n"
+            + "        \"sort_build\" : true,\n"
+            + "        \"sort_descriptions\" : [\n"
+            + "            {\n"
+            + "                \"sort_field\" : \"hits\",\n"
+            + "                \"sort_pattern\" : \"asc\"\n"
+            + "            }\n"
+            + "        ],\n"
+            + "        \"sort_queue_mem\" : 4096,\n"
+            + "        \"sort_queue_size\" : 10000000\n"
+            + "    }"
+            + "}";
+
+        String schemaJson = "{\n"
+            + "    \"columns\": [\n"
+            + "        {\n"
+            + "            \"name\": \"title\",\n"
+            + "            \"type\": \"TEXT\",\n"
+            + "            \"analyzer\": \"simple_analyzer\"\n"
+            + "        },\n"
+            + "        {\n"
+            + "            \"name\": \"subject\",\n"
+            + "            \"type\": \"TEXT\",\n"
+            + "            \"analyzer\": \"simple_analyzer\"\n"
+            + "        },\n"
+            + "        {\n"
+            + "            \"name\": \"id\",\n"
+            + "            \"type\": \"UINT32\"\n"
+            + "        },\n"
+            + "        {\n"
+            + "            \"name\": \"hits\",\n"
+            + "            \"type\": \"UINT32\"\n"
+            + "        },\n"
+            + "        {\n"
+            + "            \"name\": \"createtime\",\n"
+            + "            \"type\": \"UINT64\"\n"
+            + "        }\n"
+            + "    ]"
+            + "}";
+
+        String data_tableJson = "{\n"
+            + "    \"processor_chain_config\" : [\n"
+            + "        {\n"
+            + "            \"clusters\" : [\n"
+            + "                \"in0\"\n"
+            + "            ],\n"
+            + "            \"document_processor_chain\" : [\n"
+            + "                {\n"
+            + "                    \"class_name\" : \"TokenizeDocumentProcessor\",\n"
+            + "                    \"module_name\" : \"\",\n"
+            + "                    \"parameters\" : {\n"
+            + "                    }\n"
+            + "                }\n"
+            + "            ],\n"
+            + "            \"modules\" : [\n"
+            + "            ]\n"
+            + "        }\n"
+            + "    ],\n"
+            + "    \"processor_config\" : {\n"
+            + "        \"processor_queue_size\" : 2000,\n"
+            + "        \"processor_thread_num\" : 10\n"
+            + "    },\n"
+            + "    \"processor_rule_config\" : {\n"
+            + "        \"parallel_num\" : 1,\n"
+            + "        \"partition_count\" : 1\n"
+            + "    }\n"
+            + "}";
+
+        TableConfigGenerator tableConfigGenerator = new TableConfigGenerator(
+            indexName,
+            Settings.builder()
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 3)
+                .put(EngineSettings.HAVENASK_BUILD_CONFIG_MAX_DOC_COUNT.getKey(), 10)
+                .put(EngineSettings.HAVENASK_WAL_CONFIG_SINK_QUEUE_SIZE.getKey(), 100)
+                .put(EngineSettings.HAVENASK_HASH_MODE_HASH_FIELD.getKey(), "test")
+                .put(EngineSettings.HAVENASK_CLUSTER_JSON.getKey(), clusterJson)
+                .put(EngineSettings.HAVENASK_SCHEMA_JSON.getKey(), schemaJson)
+                .put(EngineSettings.HAVENASK_DATA_TABLE_JSON.getKey(), data_tableJson)
+                .build(),
+            mapperService,
+            configPath
+        );
+        tableConfigGenerator.generate();
+
+        {
+            Path clusterConfigPath = configPath.resolve(TABLE_DIR)
+                .resolve("0")
+                .resolve(CLUSTER_DIR)
+                .resolve(indexName + CLUSTER_FILE_SUFFIX);
+            assertTrue(Files.exists(clusterConfigPath));
+            String content = Files.readString(clusterConfigPath);
+            assertEquals(clusterJson, content);
+        }
+
+        {
+            Path schemaConfigPath = configPath.resolve(TABLE_DIR)
+                .resolve("0")
+                .resolve(SCHEMAS_DIR)
+                .resolve(indexName + SCHEMAS_FILE_SUFFIX);
+            assertTrue(Files.exists(schemaConfigPath));
+            String content = Files.readString(schemaConfigPath);
+            assertEquals(schemaJson, content);
+        }
+
+        {
+            Path dataTablesPath = configPath.resolve(TABLE_DIR)
+                .resolve("0")
+                .resolve(DATA_TABLES_DIR)
+                .resolve(indexName + DATA_TABLES_FILE_SUFFIX);
+            assertTrue(Files.exists(dataTablesPath));
+            String content = Files.readString(dataTablesPath);
+            assertEquals(data_tableJson, content);
+        }
+
+        tableConfigGenerator.remove();
+        Path clusterConfigPath = configPath.resolve(TABLE_DIR)
+            .resolve("0")
+            .resolve(BizConfigGenerator.CLUSTER_DIR)
+            .resolve(indexName + BizConfigGenerator.CLUSTER_FILE_SUFFIX);
+        assertFalse(Files.exists(clusterConfigPath));
+
+        Path schemaConfigPath = configPath.resolve(TABLE_DIR).resolve("0").resolve(SCHEMAS_DIR).resolve(indexName + SCHEMAS_FILE_SUFFIX);
+        assertFalse(Files.exists(schemaConfigPath));
+
+        Path dataTablesPath = configPath.resolve(TABLE_DIR)
+            .resolve("0")
+            .resolve(DATA_TABLES_DIR)
+            .resolve(indexName + DATA_TABLES_FILE_SUFFIX);
+        assertFalse(Files.exists(dataTablesPath));
+    }
 }


### PR DESCRIPTION
新增了一个`PUT _havenask/create/${index}`的REST接口，支持用户自定义havenask引擎配置
```
#e.g.
PUT _havenask/create/test
{
  "settings": {
    "number_of_shards":2,
    "number_of_replicas": 0
  },
  "mappings": {
    "properties": {
      "foo": {
        "type": "keyword"
      }
    }
  },
  "cluster":{
    //cluster.json配置
  },
"data_table":{
    //data_table.json配置
  },
"schema":{
    //schema.json配置
  }
}
```
目前如果用户设置了对应的配置，则会直接将用户对相关参数的配置直接写到对应的.json文件下，
没有配置则会根据之前的流程生成对应的配置。
后续会支持参数的校验等功能。