### PR TITLE
优化lucene segment metadata的更新逻辑

### DIFF
--- a/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/index/engine/HavenaskEngine.java
+++ b/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/index/engine/HavenaskEngine.java
@@ -1118,12 +1118,17 @@ public class HavenaskEngine extends InternalEngine {
             currentCheckpoint
         );
 
-        if (currentCheckpoint > lastCommitInfo.getCommitCheckpoint()) {
+        // havenask会定期刷新version文件，因此在checkpoint没有变化但检测到version文件更新时也同步更新lucene segment metadata中的commit信息
+        if (currentCheckpoint > lastCommitInfo.getCommitCheckpoint()
+            || (currentCheckpoint == lastCommitInfo.getCommitCheckpoint() && segmentVersion > lastCommitInfo.getCommitVersion())) {
             logger.info(
-                "havenask engine refresh checkpoint, checkpoint time: {}, current checkpoint: {}, last commit " + "checkpoint: {}",
+                "havenask engine refresh checkpoint, checkpoint time: {}, current checkpoint: {}, last commit checkpoint: {}"
+                    + ", havenask version: {}, last commit version: {}",
                 havenaskTime,
                 currentCheckpoint,
-                lastCommitInfo.getCommitCheckpoint()
+                lastCommitInfo.getCommitCheckpoint(),
+                segmentVersion,
+                lastCommitInfo.getCommitVersion()
             );
             refreshCommitInfo(havenaskTimePoint, segmentVersion, currentCheckpoint);
 


### PR DESCRIPTION
fix: https://github.com/alibaba/havenask-federation/issues/470
现在fed在没有写入文档时，checkpoint没有变化时，lucene segment metadata的version随着havenask的version更新而更新