### PR TITLE
qrs sql接口post body使用UTF-8编码

### DIFF
--- a/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/rpc/http/QrsHttpClient.java
+++ b/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/rpc/http/QrsHttpClient.java
@@ -56,7 +56,7 @@ public class QrsHttpClient extends HavenaskHttpClient implements QrsClient {
         Response response = getClient().performRequest(request);
         long end = System.nanoTime();
         logger.debug("execute sql: {} cost: {} us", qrsSqlRequest.getSql(), (end - start) / 1000);
-        String responseString = EntityUtils.toString(response.getEntity());
+        String responseString = EntityUtils.toString(response.getEntity(), Consts.UTF_8);
         return new QrsSqlResponse(responseString, response.getStatusLine().getStatusCode());
     }
 

--- a/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/rpc/http/QrsHttpClient.java
+++ b/elastic-fed/modules/havenask-engine/src/main/java/org/havenask/engine/rpc/http/QrsHttpClient.java
@@ -16,6 +16,7 @@ package org.havenask.engine.rpc.http;
 
 import java.io.IOException;
 
+import org.apache.http.Consts;
 import org.apache.http.entity.ContentType;
 import org.apache.http.nio.entity.NStringEntity;
 import org.apache.http.util.EntityUtils;
@@ -51,7 +52,7 @@ public class QrsHttpClient extends HavenaskHttpClient implements QrsClient {
         if (qrsSqlRequest.getKvpair() != null) {
             query += "&&kvpair=" + qrsSqlRequest.getKvpair();
         }
-        request.setEntity(new NStringEntity(query, ContentType.TEXT_PLAIN));
+        request.setEntity(new NStringEntity(query, ContentType.create("text/plain", Consts.UTF_8)));
         Response response = getClient().performRequest(request);
         long end = System.nanoTime();
         logger.debug("execute sql: {} cost: {} us", qrsSqlRequest.getSql(), (end - start) / 1000);


### PR DESCRIPTION
之前使用默认的Consts.ISO_8859_1编码，编码中文存在问题，导致全文检索无法检索到中文以及sql结果乱码，修改为UTF-8编码;